### PR TITLE
fix: import error for numpy in JSON decoder

### DIFF
--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -4,8 +4,6 @@ import os.path
 import time
 import types
 
-import numpy as np
-
 COLORS = {
   'RESET': "\033[m",
   'YELLOW': "\033[1;93m",
@@ -62,6 +60,16 @@ def sip(iterable, block_size):
 
 class NumpyEncoder(json.JSONEncoder):
   def default(self, obj):
+    try:
+      import numpy as np
+    except ImportError:
+      try:
+        return json.JSONEncoder.default(self, obj)
+      except TypeError:
+        if 'numpy' in str(type(obj)):
+          print(yellow("Type " + str(type(obj)) + " requires a numpy installation to encode. Try `pip install numpy`."))
+        raise
+
     if isinstance(obj, np.ndarray):
       return obj.tolist()
     if isinstance(obj, np.integer):

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -4,6 +4,8 @@ import os.path
 import time
 import types
 
+import numpy as np
+
 COLORS = {
   'RESET': "\033[m",
   'YELLOW': "\033[1;93m",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0
 google-cloud-storage>=1.24.1
+numpy
 protobuf>=3.3.0
 requests>=2.22.0
 six>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0
 google-cloud-storage>=1.24.1
-numpy
 protobuf>=3.3.0
 requests>=2.22.0
 six>=1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,5 @@ packages = cloudfiles
 test =
     pytest
     moto
+numpy =
+    numpy


### PR DESCRIPTION
I was trying to avoid a numpy dependency, but that function is very
useful for everyone that is currently using CloudFiles. I considered
using a try except for ImportError, but that would have been confusing
for people used to seamless operation with numpy types.

Resolves #4 