### PR TITLE
feat: add transcode to compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ cff = CloudFiles('file:///source_location')
 cfg = CloudFiles('gs://dest_location')
 
 # Transfer all files from local filesys to google cloud storage
-cfg.transfer_from(cff, block_size=64)
+cfg.transfer_from(cff, block_size=64) # in blocks of 64 files
 cff.transfer_to(cfg, block_size=64)
+cff.transfer_to(cfg, block_size=64, reencode='br') # change encoding to brotli
 cfg[:] = cff # default block size 64
 ```
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,27 @@ cfg[:] = cff # default block size 64
 
 Transfer semantics provide a simple way to perform bulk file transfers. Use the `block_size` parameter to adjust the number of files handled in a given pass. This can be important for preventing memory blow-up and reducing latency between batches.
 
+## transcode
+
+```python
+from cloudfiles.compression import transcode
+
+files = cf.get(...) 
+
+for file in transcode(files, 'gzip'):
+  file['content'] # gzipped file content regardless of source
+
+transcode(files, 
+  encoding='gzip', # any cf compatible compression scheme
+  in_place=False, # modify the files in-place to save memory
+  progress=True # progress bar
+)
+```
+
+Sometimes we want to change the encoding type of a set of arbitrary files (often when moving them around to another storage system). `transcode` will take the output of `get` and transcode the resultant files into a new format. `transcode` respects the `raw` attribute which indicates that the contents are already compressed and will decompress them first before recompressing. If the input data are already compressed to the correct output encoding, it will simply pass it through without going through a decompression/recompression cycle.
+
+`transcode` returns a generator so that the transcoding can be done in a streaming manner.
+
 ## Credits
 
 CloudFiles is derived from the [CloudVolume.Storage](https://github.com/seung-lab/cloud-volume/tree/master/cloudvolume/storage) system.  

--- a/automated_test.py
+++ b/automated_test.py
@@ -238,6 +238,30 @@ def test_compress_level(compression_method):
 
     rmtree(filepath)
 
+@pytest.mark.parametrize("dest_encoding", (None, "gzip", "br", "zstd"))
+def test_transcode(dest_encoding):
+  from cloudfiles import CloudFiles, compression
+  base_text = b'hello world'
+  encodings = [ None, "gzip", "br", "zstd" ]
+
+  varied_texts = []
+
+  ans = compression.compress(base_text, dest_encoding)
+
+  for i in range(200):
+    src_encoding = encodings[i % len(encodings)]
+    print(src_encoding)
+    varied_texts.append({
+      "path": str(i),
+      "content": compression.compress(base_text, src_encoding),
+      "raw": src_encoding is not None,
+      "compress": src_encoding,
+    })
+
+  transcoded = (x['content'] for x in compression.transcode(varied_texts, dest_encoding))
+  for content in transcoded:
+    assert content == ans
+
 @pytest.mark.parametrize("protocol", ('mem', 'file', 's3'))
 def test_list(s3, protocol):  
   from cloudfiles import CloudFiles, exceptions

--- a/automated_test.py
+++ b/automated_test.py
@@ -380,9 +380,18 @@ def test_transfer_semantics(compression):
   cff.transfer_to(cfm.cloudpath)
   assert sorted(list(cfm)) == sorted([ str(i) for i in range(N) ])
   assert [ f['content'] for f in cfm[:] ] == [ content ] * N  
-
-  cff.delete(list(cff))
   cfm.delete(list(cfm))
+
+  cff.transfer_to(cfm.cloudpath, reencode='br')
+  assert sorted(list(cfm)) == sorted([ str(i) for i in range(N) ])
+  assert [ f['content'] for f in cfm[:] ] == [ content ] * N  
+
+  data = cfm._get_connection()._data
+  data = [ os.path.splitext(d)[1] for d in data.keys() ] 
+  assert all([ ext == '.br' for ext in data ])
+
+  cfm.delete(list(cfm))
+  cff.delete(list(cff))
 
 def test_slice_notation():
   from cloudfiles import CloudFiles, exceptions

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -123,6 +123,8 @@ class CloudFiles(object):
             'content': content, 
             'byte_range': (start, end),
             'error': error,
+            'compress': compression type,
+            'raw': boolean,
           }
         ]
     """


### PR DESCRIPTION
```python
cloudfiles/compression.py

def transcode(
  files, encoding, level=None, 
  progress=False, in_place=False
):
  """
  Given the output of get, which may include raw files, 
  transcode the compresson scheme into the one specified by 
  encoding. If the files are raw and the schemes match, 
  the decompression-compression cycle will be skipped.

  level: input of compression level e.g. 6 for gzip
  progress: show a progress bar
  in_place: modify the files in-place to save memory

  Yields: {
    'path': ,
    'content': ,
    'compress': ,
    'raw': ,
  }
```