### PR TITLE
feat: perform md5 integrity checks

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -257,8 +257,8 @@ def test_compress_level(compression_method):
     assert content == retrieved
 
     conn = cf._get_connection()
-    _, e = conn.get_file("info")
-    assert e == compression_method
+    _, encoding, server_md5 = conn.get_file("info")
+    assert encoding == compression_method
 
     assert cf.get('nonexistentfile') is None
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -14,8 +14,12 @@ from tqdm import tqdm
 import google.cloud.storage 
 
 from . import compression, paths
-from .exceptions import UnsupportedProtocolError
-from .lib import mkdir, toiter, scatter, jsonify, duplicates, first, sip, STRING_TYPES
+from .exceptions import UnsupportedProtocolError, MD5IntegrityError
+from .lib import (
+  mkdir, toiter, scatter, jsonify, 
+  duplicates, first, sip, STRING_TYPES, 
+  md5
+)
 from .threaded_queue import ThreadedQueue, DEFAULT_THREADS
 from .scheduler import schedule_jobs
 
@@ -130,16 +134,27 @@ class CloudFiles(object):
     """
     paths, mutliple_return = toiter(paths, is_iter=True)
 
+    def check_md5(path, content, server_md5):
+      if server_md5 is not None:
+        computed_md5 = md5(content)
+
+        if computed_md5.rstrip("==") != server_md5.rstrip("=="):
+          raise MD5IntegrityError("{} failed its md5 check. server md5: {} computed md5: {}".format(
+            path, server_md5, computed_md5
+          ))
+
     def download(path):
       path, start, end = path_to_byte_range(path)
       error = None
       content = None
       encoding = None
+      server_md5 = None
       try:
         with self._get_connection() as conn:
-          content, encoding = conn.get_file(path, start=start, end=end)
+          content, encoding, server_md5 = conn.get_file(path, start=start, end=end)
         if not raw:
           content = compression.decompress(content, encoding, filename=path)
+        check_md5(path, content, server_md5)
       except Exception as err:
         error = err
 

--- a/cloudfiles/exceptions.py
+++ b/cloudfiles/exceptions.py
@@ -20,3 +20,9 @@ class UnsupportedCompressionType(Exception):
   by the storage interface.
   """
   pass
+
+class MD5IntegrityError(Exception):
+  """
+  Failed MD5 digest check.
+  """
+  pass

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1,4 +1,7 @@
 import six
+
+import base64
+import binascii
 from collections import defaultdict
 import json
 import os.path
@@ -15,7 +18,7 @@ import tenacity
 
 from .compression import COMPRESSION_TYPES
 from .connectionpools import S3ConnectionPool, GCloudBucketPool, MemoryPool, MEMORY_DATA
-from .lib import mkdir, sip, PYTHON3
+from .lib import mkdir, sip, md5, PYTHON3
 
 COMPRESSION_EXTENSIONS = ('.gz', '.br', '.zstd')
 GZIP_TYPES = (True, 'gzip', 1)
@@ -126,9 +129,9 @@ class FileInterface(StorageInterface):
           data = f.read(num_bytes)
         else:
           data = f.read()
-      return data, encoding
+      return data, encoding, None
     except IOError:
-      return None, encoding
+      return None, encoding, None
 
   def size(self, file_path):
     path = self.get_path_to_file(file_path)
@@ -265,7 +268,7 @@ class MemoryInterface(StorageInterface):
       encoding = None
 
     slc = slice(start, end)
-    return self._data[path][slc], encoding
+    return self._data[path][slc], encoding, None
 
   def size(self, file_path):
     path = self.get_path_to_file(file_path)
@@ -370,6 +373,8 @@ class GoogleCloudStorageInterface(StorageInterface):
 
     if cache_control:
       blob.cache_control = cache_control
+
+    blob.md5_hash = md5(content)
     blob.upload_from_string(content, content_type)
 
   @retry
@@ -385,9 +390,9 @@ class GoogleCloudStorageInterface(StorageInterface):
     try:
       # blob handles the decompression so the encoding is None
       content = blob.download_as_string(start=start, end=end, raw_download=True)
-      return content, blob.content_encoding
+      return (content, blob.content_encoding, blob.md5_hash)
     except google.cloud.exceptions.NotFound as err:
-      return None, None
+      return (None, None, None)
 
   @retry
   def size(self, file_path):
@@ -502,13 +507,14 @@ class HttpInterface(StorageInterface):
       return None, None
     resp.raise_for_status()
 
-    if 'Content-Encoding' not in resp.headers:
-      return resp.content, None
+    etag = resp.headers.get('etag', None)
+    content_encoding = resp.headers.get('Content-Encoding', None)
+
     # requests automatically decodes these
-    elif resp.headers['Content-Encoding'] in ('', 'gzip', 'deflate', 'br'):
-      return resp.content, None
-    else:
-      return resp.content, resp.headers['Content-Encoding']
+    if content_encoding in (None, '', 'gzip', 'deflate', 'br'):
+      content_encoding = None
+    
+    return resp.content, content_encoding, etag
 
   @retry
   def exists(self, file_path):
@@ -537,7 +543,11 @@ class S3Interface(StorageInterface):
     return posixpath.join(self._path.no_bucket_basepath, self._path.layer, file_path)
 
   @retry
-  def put_file(self, file_path, content, content_type, compress, cache_control=None, ACL="bucket-owner-full-control"):
+  def put_file(
+    self, file_path, content, 
+    content_type, compress, 
+    cache_control=None, ACL="bucket-owner-full-control"
+  ):
     key = self.get_path_to_file(file_path)
 
     attrs = {
@@ -546,6 +556,7 @@ class S3Interface(StorageInterface):
       'Key': key,
       'ContentType': (content_type or 'application/octet-stream'),
       'ACL': ACL,
+      'ContentMD5': md5(content),
     }
 
     # keep gzip as default
@@ -563,7 +574,7 @@ class S3Interface(StorageInterface):
 
     self._conn.put_object(**attrs)
 
-  @retry
+  # @retry
   def get_file(self, file_path, start=None, end=None):
     """
     There are many types of execptions which can get raised
@@ -588,10 +599,21 @@ class S3Interface(StorageInterface):
       if 'ContentEncoding' in resp:
         encoding = resp['ContentEncoding']
 
-      return resp['Body'].read(), encoding
+      # s3 etags return hex digests but we need the base64 encoding
+      # to make uniform comparisons. 
+      # example s3 etag: "31ee76261d87fed8cb9d4c465c48158c"
+      etag = resp.get('ETag', None)
+      print(etag)
+      if etag is not None:
+        etag = etag[1:-1] # strip quotes
+        print(etag)
+        etag = base64.b64encode(binascii.unhexlify(etag)).decode('utf8')
+        print(etag)
+
+      return resp['Body'].read(), encoding, etag
     except botocore.exceptions.ClientError as err: 
       if err.response['Error']['Code'] == 'NoSuchKey':
-        return None, None
+        return None, None, None
       else:
         raise
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -574,7 +574,7 @@ class S3Interface(StorageInterface):
 
     self._conn.put_object(**attrs)
 
-  # @retry
+  @retry
   def get_file(self, file_path, start=None, end=None):
     """
     There are many types of execptions which can get raised
@@ -603,12 +603,9 @@ class S3Interface(StorageInterface):
       # to make uniform comparisons. 
       # example s3 etag: "31ee76261d87fed8cb9d4c465c48158c"
       etag = resp.get('ETag', None)
-      print(etag)
       if etag is not None:
-        etag = etag[1:-1] # strip quotes
-        print(etag)
+        etag = etag.lstrip('"').rstrip('"')
         etag = base64.b64encode(binascii.unhexlify(etag)).decode('utf8')
-        print(etag)
 
       return resp['Body'].read(), encoding, etag
     except botocore.exceptions.ClientError as err: 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -507,14 +507,17 @@ class HttpInterface(StorageInterface):
       return None, None
     resp.raise_for_status()
 
-    etag = resp.headers.get('etag', None)
+    # Don't check MD5 for http because the etag can come in many
+    # forms from either GCS, S3 or another service entirely. We
+    # probably won't figure out how to decode it right.
+    # etag = resp.headers.get('etag', None)
     content_encoding = resp.headers.get('Content-Encoding', None)
 
     # requests automatically decodes these
     if content_encoding in (None, '', 'gzip', 'deflate', 'br'):
       content_encoding = None
     
-    return resp.content, content_encoding, etag
+    return resp.content, content_encoding, None 
 
   @retry
   def exists(self, file_path):

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -388,9 +388,11 @@ class GoogleCloudStorageInterface(StorageInterface):
       end = int(end - 1)      
 
     try:
-      # blob handles the decompression so the encoding is None
+      # md5_hash is not useful if the object is a composite download, 
+      # so try testing for that using component_count.
       content = blob.download_as_string(start=start, end=end, raw_download=True)
-      return (content, blob.content_encoding, blob.md5_hash)
+      md5_hash = blob.md5_hash if blob.component_count is None else None
+      return (content, blob.content_encoding, md5_hash)
     except google.cloud.exceptions.NotFound as err:
       return (None, None, None)
 

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import itertools
 import json
 import os.path
@@ -129,3 +131,11 @@ def scatter(sequence, n):
   sequence = list(sequence)
   for i in range(n):
     yield sequence[i::n]
+
+def md5(binary):
+  if isinstance(binary, str):
+    binary = binary.encode('utf8')
+
+  return base64.b64encode(
+    hashlib.md5(binary).digest()
+  ).decode('utf8')

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -9,9 +9,11 @@ import sys
 
 if sys.version_info < (3,0,0):
   STRING_TYPES = (str, unicode)
+  UNICODE_TYPE = unicode
   PYTHON3 = False
 else:
   STRING_TYPES = (str,)
+  UNICODE_TYPE = str
   PYTHON3 = True
 
 COLORS = {
@@ -133,7 +135,7 @@ def scatter(sequence, n):
     yield sequence[i::n]
 
 def md5(binary):
-  if isinstance(binary, str):
+  if isinstance(binary, UNICODE_TYPE):
     binary = binary.encode('utf8')
 
   return base64.b64encode(


### PR DESCRIPTION
A small download test seemed to show no significant adverse performance impact from this computation.

One important ease-of-use consideration is how to process strings that are ingested. Do we require strict binary input to CloudFiles or can we assume strings are utf8? If strings are not utf8 a simple remedy for the end user is to encode their strings to binary before sending it into CF. However, python27 is more tricky as strings and bytes are the same so not as easily detected. We could simply disable this check for py27 or drop support.

Should we allow disabling the md5 checks? If a problem with them develops it might make it easier for users to work around those problems.