### PR TITLE
feat: reenable md5 for GCS

### DIFF
--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -390,14 +390,14 @@ class GoogleCloudStorageInterface(StorageInterface):
     except google.cloud.exceptions.NotFound as err:
       return (None, None, None, None)
 
-    # hash_type = "md5"
-    # hash_value = blob.md5_hash if blob.component_count is None else None
+    hash_type = "md5"
+    hash_value = blob.md5_hash if blob.component_count is None else None
 
-    # if hash_value is None and blob.crc32c is not None:
-    #   hash_type = "crc32c"
-    #   hash_value = blob.crc32c
+    if hash_value is None and blob.crc32c is not None:
+      hash_type = "crc32c"
+      hash_value = blob.crc32c
 
-    return (content, blob.content_encoding, None, None)
+    return (content, blob.content_encoding, hash_value, hash_type)
 
   @retry
   def size(self, file_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ chardet>=3.0.4
 gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0
-google-cloud-storage>=1.30.0
+google-cloud-storage>=1.31.1
 google-crc32c>=1.0.0
 protobuf>=3.3.0
 requests>=2.22.0


### PR DESCRIPTION
The new release of `google-cloud-storage==1.31.1` has the fixes in it for parsing the MD5 correctly.