### PR TITLE
chore: upgrade deflate to a standard install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ brotli
 crc32c
 chardet>=3.0.4
 click
+deflate>=0.2.0
 gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@ setuptools.setup(
   setup_requires=['pbr'],
   python_requires="~=3.6", # >= 3.6 < 4.0
   include_package_data=True,
-  extras_require={
-    "deflate": [ "deflate" ],
-  },
   entry_points={
     "console_scripts": [
       "cloudfiles=cloudfiles_cli:main"


### PR DESCRIPTION
As of 0.2.0, three issues with deflate were fixed:
- Memory leak
- -fPIC for src instsall
- Binaries released for major platforms

Thanks @dcwatson!