### PR TITLE
fix: preserve order for get_json

### DIFF
--- a/cloudfiles/scheduler.py
+++ b/cloudfiles/scheduler.py
@@ -20,7 +20,11 @@ def schedule_threaded_jobs(
   
   desc = progress if isinstance(progress, STRING_TYPES) else None
 
-  pbar = tqdm(total=total, desc=desc, disable=(not progress))
+  if isinstance(progress, tqdm):
+    pbar = progress
+  else:
+    pbar = tqdm(total=total, desc=desc, disable=(not progress))
+
   results = []
   
   def updatefn(fn):
@@ -50,7 +54,11 @@ def schedule_green_jobs(
 
   desc = progress if isinstance(progress, STRING_TYPES) else None
 
-  pbar = tqdm(total=total, desc=desc, disable=(not progress))
+  if isinstance(progress, tqdm):
+    pbar = progress
+  else:
+    pbar = tqdm(total=total, desc=desc, disable=(not progress))
+
   results = []
   
   def updatefn(fn):
@@ -89,7 +97,15 @@ def schedule_jobs(
   if concurrency < 0:
     raise ValueError("concurrency value cannot be negative: {}".format(concurrency))
   elif concurrency == 0:
-    return [ fn() for fn in tqdm(fns, disable=(not progress), desc=progress) ]
+    if isinstance(progress, tqdm):
+      pbar = progress
+      results = []
+      for fn in fns:
+        results.append(fn())
+        pbar.update()
+      return results
+    else:
+      return [ fn() for fn in tqdm(fns, disable=(not progress), desc=progress) ]
 
   if green:
     return schedule_green_jobs(fns, concurrency, progress, total)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description-file = README.md
 author = William Silversmith
 author-email = ws9@princeton.edu
 home-page = https://github.com/seung-lab/cloud-files/
-license = BSD
+license = License :: OSI Approved :: BSD License
 classifier =
     Intended Audience :: Developers
     Development Status :: 4 - Beta


### PR DESCRIPTION
feat: allow passing progress as a tqdm instance

refactor: use comute_url for more tests

If using get_json you lose the path information per file so you can't sort them if you need to, so the sorting needs to happen automatically.