### PR TITLE
fix: segfault on MacOS parallel & dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ requests>=2.22.0
 six>=1.14.0
 tenacity>=4.10.0
 tqdm
-urllib3[secure,brotli]>=1.25.11,<1.26.0
+urllib3[secure]>=1.26.3
 zstandard
 rsa>=4.6,!=4.7.0


### PR DESCRIPTION
Using cf.get with parallel on MacOS was causing segfaults due to the non-forksafe behavior of grand central dispatch when it searches for proxy servers. We disable proxies on Mac to avoid this issues when using parallel.

Our restrictions on urllib3 have become outdated as is its download of brotlipy (no obsolete). 