### PR TITLE
feat: enable md5 validation for multipart s3 downloads

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,45 @@
 CHANGES
 =======
 
+1.25.3
+------
+
+* fix: ensure all exceptions are raised (#48)
+
+1.25.2
+------
+
+* chore: bump rsa to working 4.7.2 (the auth bug should be fixed)
+
+1.25.1
+------
+
+* fix: segfault on MacOS parallel & dependency issues (#44)
+* chore: rsa issue fixed in 4.7.1, so only exclude 4.7.0
+
+1.25.0
+------
+
+* feat(requester pays): GCS and S3 (#41)
+* docs: rename "python package" to "test suite"
+* chore: rename python-package to test-suite
+* docs: replace travis badge with actions badge
+* chore: remove travis in favor of github actions
+* fix: ensure test dependencies are installed
+* test: remove flake8 test
+* Create python-package.yml
+
+1.24.1
+------
+
+* fix(external): rsa 4.7 (GCP dep) broken in multi-threading
+
+1.24.0
+------
+
+* docs: show how to use storage class
+* feat: allow user to specify storage\_class for cloud uploads (#39)
+
 1.23.2
 ------
 

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -158,3 +158,43 @@ def md5(binary):
   return base64.b64encode(
     hashlib.md5(binary).digest()
   ).decode('utf8')
+
+# Below code adapted from: 
+# https://teppen.io/2018/10/23/aws_s3_verify_etags/
+
+def calc_s3_multipart_etag(content, partsize):
+    md5_digests = []
+
+    for i in range(0, len(content), partsize):
+      chunk = content[i:i+partsize]
+      # import pdb; pdb.set_trace()
+      md5_digests.append(hashlib.md5(chunk).digest())
+    return hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))
+
+def validate_s3_multipart_etag(content, etag):
+  filesize = len(content)
+  num_parts = int(etag.split('-')[1])
+
+  def factor_of_1MB():
+    x = filesize / int(num_parts)
+    y = x % 1048576
+    return int(x + 1048576 - y)
+
+  def possible_partsizes(partsize):
+    return partsize < filesize and (float(filesize) / float(partsize)) <= num_parts
+
+  partsizes = [ 
+    8388608, # aws_cli/boto3 aka 8MiB (2**23)
+    15728640, # s3cmd (not quite 16 MiB??, 2**23.90689)
+    factor_of_1MB() # Used by many clients to upload large files
+  ]
+
+  for partsize in filter(possible_partsizes, partsizes):
+    if etag == calc_s3_multipart_etag(content, partsize):
+      return True
+
+  return False
+
+
+
+

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -163,12 +163,12 @@ def md5(binary):
 # https://teppen.io/2018/10/23/aws_s3_verify_etags/
 
 def calc_s3_multipart_etag(content, partsize):
-    md5_digests = []
+  md5_digests = []
 
-    for i in range(0, len(content), partsize):
-      chunk = content[i:i+partsize]
-      md5_digests.append(hashlib.md5(chunk).digest())
-    return hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))
+  for i in range(0, len(content), partsize):
+    chunk = content[i:i+partsize]
+    md5_digests.append(hashlib.md5(chunk).digest())
+  return hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))
 
 def validate_s3_multipart_etag(content, etag):
   filesize = len(content)

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -167,7 +167,6 @@ def calc_s3_multipart_etag(content, partsize):
 
     for i in range(0, len(content), partsize):
       chunk = content[i:i+partsize]
-      # import pdb; pdb.set_trace()
       md5_digests.append(hashlib.md5(chunk).digest())
     return hashlib.md5(b''.join(md5_digests)).hexdigest() + '-' + str(len(md5_digests))
 
@@ -177,7 +176,7 @@ def validate_s3_multipart_etag(content, etag):
 
   def factor_of_1MB():
     x = filesize / int(num_parts)
-    y = x % 1048576
+    y = x % 1048576 # 2**20 or 1 MiB
     return int(x + 1048576 - y)
 
   def possible_partsizes(partsize):

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -183,8 +183,8 @@ def validate_s3_multipart_etag(content, etag):
     return partsize < filesize and (float(filesize) / float(partsize)) <= num_parts
 
   partsizes = [ 
-    8388608, # aws_cli/boto3 aka 8MiB (2**23)
-    15728640, # s3cmd (not quite 16 MiB??, 2**23.90689)
+    8388608, # aws_cli/boto3 aka 8MiB (8 * 2**20)
+    15728640, # s3cmd aka 15 MiB (15 * 2**20)
     factor_of_1MB() # Used by many clients to upload large files
   ]
 


### PR DESCRIPTION
We used the following documents as a guide:

- https://teppen.io/2018/10/23/aws_s3_verify_etags/
- https://teppen.io/2018/06/23/aws_s3_etags/

Gracious thank you to the authors of those articles for the code and advice.

The PR here is a bit different. As the S3 logic is particular to Amazon, it was not possible to do this in the common logic. This means the multipart code will retry while other md5 failures will not. However, should they all be retrying?

Resolves #49 
