### PR TITLE
fix: transfer paths from windows correctly

### DIFF
--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -821,8 +821,8 @@ class CloudFiles(object):
           downloaded = compression.transcode(downloaded, reencode, in_place=True)
 
         if (
-              cf_src._path.protocol == "file" 
-          and cf_dest._path.protocol != "file" 
+              cf_src._path.protocol == "file"
+          and self._path.protocol != "file"
           and os.path.sep != posixpath.sep
         ):
           for download in downloaded:

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -819,6 +819,15 @@ class CloudFiles(object):
         downloaded = cf_src.get(block_paths, raw=True, progress=False)
         if reencode is not None:
           downloaded = compression.transcode(downloaded, reencode, in_place=True)
+
+        if (
+              cf_src._path.protocol == "file" 
+          and cf_dest._path.protocol != "file" 
+          and os.path.sep != posixpath.sep
+        ):
+          for download in downloaded:
+            download["path"] = posixpath.sep.join(download["path"].split(os.path.sep))
+
         self.puts(downloaded, raw=True, progress=False)
         pbar.update(len(block_paths))
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -194,8 +194,8 @@ class FileInterface(StorageInterface):
     filenames = []
 
     remove = layer_path
-    if len(remove) and remove[-1] != '/':
-      remove += '/'
+    if len(remove) and remove[-1] != os.path.sep:
+      remove += os.path.sep
 
     if flat:
       for file_path in glob(path):


### PR DESCRIPTION
`cloudfiles cp -r path matrix://bucket/` was copying stuff like:

`bucket/C:\\path\\file\\`

This was because the path sep was not being considered in the file interface listing operator and we were not converting from Windows to posix during transfers.