### PR TITLE
feat(cli): adds verify command 

### DIFF
--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -697,6 +697,18 @@ class CloudFiles(object):
     return first(results.values())
 
   def head(self, paths, total=None, progress=None):
+    """
+    Retrieves basic metadata about the indicated files including
+    last modified, file size in bytes, and an integrity check
+    hash if available (usually md5 or crc32c).
+
+    paths: one or more file paths relative to the cloudpath.
+    total: manually provide a progress bar size if paths does
+      not support the `len` operator.
+    progress: selectively enable or disable progress just for this
+      function call. If progress is a string, it sets the 
+      text of the progress bar.
+    """
     paths, return_multiple = toiter(paths, is_iter=True)
     progress = nvl(progress, self.progress)
     results = {}

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import hashlib
 import itertools
 import orjson
@@ -155,7 +156,7 @@ def crc32c(binary):
   """
   return crc32clib.value(binary) # an integer
 
-def md5(binary):
+def md5(binary, base=64):
   """
   Returns the md5 of a binary string 
   in base64 format.
@@ -163,9 +164,26 @@ def md5(binary):
   if isinstance(binary, UNICODE_TYPE):
     binary = binary.encode('utf8')
 
-  return base64.b64encode(
-    hashlib.md5(binary).digest()
-  ).decode('utf8')
+  digest = hashlib.md5(binary)
+  if base == 64:
+    return base64.b64encode(digest.digest()).decode('utf8')
+  elif base == 16:
+    return digest.hexdigest()
+  else:
+    raise ValueError(f"base {base} must be 16 or 64.")
+
+def md5_equal(hash_a, hash_b):
+  hash_a = hash_a.rstrip('"').lstrip('"')
+  hash_b = hash_b.rstrip('"').lstrip('"')
+
+  b16_to_b64 = lambda hash_x: base64.b64encode(binascii.unhexlify(hash_x)).decode('utf8')
+
+  if len(hash_a) == 32:
+    hash_a = b16_to_b64(hash_a)
+  if len(hash_b) == 32:
+    hash_b = b16_to_b64(hash_b)
+
+  return hash_a == hash_b
 
 # Below code adapted from: 
 # https://teppen.io/2018/10/23/aws_s3_verify_etags/

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -475,18 +475,26 @@ def verify(source, target, only_matching, verbose, md5):
   source = normalize_path(source)
   target = normalize_path(target)
   if ispathdir(source) != ispathdir(target):
-    print("cloudfiles: verify source and target must both be single files or directories.")
+    print("cloudfiles: verify source and target must both be files or directories.")
     return
 
   if not md5 and (get_protocol(source) == "file" or get_protocol(target) == "file"):
     print("cloudfiles: verify source and target must be object storage without --md5 option. The filesystem does not store hash information.")
     return
 
-  cfsrc = CloudFiles(source)
-  src_files = set(list(cfsrc))
+  if ispathdir(source):
+    cfsrc = CloudFiles(source)
+    src_files = set(list(cfsrc))
+  else:
+    cfsrc = CloudFiles(os.path.dirname(source))
+    src_files = set([ os.path.basename(source) ])
   
-  cftarget = CloudFiles(target)
-  target_files = set(list(cftarget))
+  if ispathdir(target):
+    cftarget = CloudFiles(target)
+    target_files = set(list(cftarget))
+  else:
+    cftarget = CloudFiles(os.path.dirname(target))
+    target_files = set([ os.path.basename(target) ])  
   
   matching_files = src_files.intersection(target_files)
   mismatched_files = src_files | target_files

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -489,10 +489,10 @@ def verify(source, target, only_matching, verbose, md5):
   target_files = set(list(cftarget))
   
   matching_files = src_files.intersection(target_files)
+  mismatched_files = src_files | target_files
+  mismatched_files -= matching_files
 
   if not only_matching:
-    mismatched_files = src_files | target_files
-    mismatched_files -= matching_files
     if len(mismatched_files) > 0:
       if verbose:
         print(f"Extra source files:")
@@ -535,7 +535,7 @@ def verify(source, target, only_matching, verbose, md5):
       failed_files.append(filename)
 
   if not failed_files:
-    print(green(f"success. {len(matching_files)} files matching."))
+    print(green(f"success. {len(matching_files)} files matching. {len(mismatched_files)} ignored."))
     return
 
   if verbose:
@@ -560,5 +560,5 @@ def verify(source, target, only_matching, verbose, md5):
       print(f'{sm["Content-Length"]:<12} {tm["Content-Length"]:<12} {sm["Content-Encoding"] or "None":<4} {tm["Content-Encoding"] or "None":<4} {sm["ETag"] or "None":<34} {tm["ETag"] or "None":<34} {sm["Content-Md5"] or "None":<24} {tm["Content-Md5"] or "None":<24} {filename}')
     print("--")
 
-  print(red(f"failed. {len(failed_files)} failed. {len(matching_files) - len(failed_files)} succeeded."))
+  print(red(f"failed. {len(failed_files)} failed. {len(matching_files) - len(failed_files)} succeeded. {len(mismatched_files)} ignored."))
 

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -481,12 +481,19 @@ def verify(source, target, only_matching, verbose):
 
   if verbose:
     failed_files.sort()
-    print("src bytes\ttarget bytes\tsrc etag\t\t\t\ttarget etag\t\t\t\tfilename")
+    header = [
+      "src bytes".ljust(16),
+      "target bytes".ljust(16),
+      "src etag".ljust(40),
+      "target etag".ljust(40),
+      "filename"
+    ]
+    print("".join(header))
     for filename in failed_files:
       sm = src_meta[filename]
       tm = target_meta[filename]
       print(f'{sm["Content-Length"]:<15}\t{tm["Content-Length"]:<15}\t{sm["ETag"]:<34}\t{tm["ETag"]:<34}\t{filename}')
     print("--")
-    
+
   print(red(f"failed. {len(failed_files)} failed. {len(matching_files) - len(failed_files)} succeeded."))
 

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -429,7 +429,8 @@ def head(paths):
 @click.argument("source")
 @click.argument("target")
 @click.option('-m', '--only-matching', is_flag=True, default=False, help="Only check files with matching filenames.", show_default=True)
-def verify(source, target, only_matching):
+@click.option('-v', '--verbose', is_flag=True, default=False, help="Output detailed information of failed matches.", show_default=True)
+def verify(source, target, only_matching, verbose):
   """
   Validates that the checksums of two files
   or two directories match.
@@ -452,8 +453,11 @@ def verify(source, target, only_matching):
     mismatched_files = src_files | target_files
     mismatched_files -= matching_files
     if len(mismatched_files) > 0:
-      # print(f"Extra files:")
-      # print("\n".join(mismatched_files))
+      if verbose:
+        print(f"Extra source files:")
+        print("\n".join(src_files - matching_files))
+        print(f"Extra target files:")
+        print("\n".join(target_files - matching_files))
       print(red(f"failed. {len(src_files)} source files, {len(target_files)} target files."))
       return
 
@@ -475,14 +479,14 @@ def verify(source, target, only_matching):
     print(green(f"success. {len(matching_files)} files matching."))
     return
 
-  failed_files.sort()
-
-  print("src bytes\ttarget bytes\tsrc etag\t\t\t\ttarget etag\t\t\t\tfilename")
-  for filename in failed_files:
-    sm = src_meta[filename]
-    tm = target_meta[filename]
-    print(f'{sm["Content-Length"]:<15}\t{tm["Content-Length"]:<15}\t{sm["ETag"]:<34}\t{tm["ETag"]:<34}\t{filename}')
-
-  print("--")
+  if verbose:
+    failed_files.sort()
+    print("src bytes\ttarget bytes\tsrc etag\t\t\t\ttarget etag\t\t\t\tfilename")
+    for filename in failed_files:
+      sm = src_meta[filename]
+      tm = target_meta[filename]
+      print(f'{sm["Content-Length"]:<15}\t{tm["Content-Length"]:<15}\t{sm["ETag"]:<34}\t{tm["ETag"]:<34}\t{filename}')
+    print("--")
+    
   print(red(f"failed. {len(failed_files)} failed. {len(matching_files) - len(failed_files)} succeeded."))
 

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -539,18 +539,24 @@ def verify(source, target, only_matching, verbose, md5):
 
   if verbose:
     failed_files.sort()
+
     header = [
-      "src bytes".ljust(16),
-      "target bytes".ljust(16),
-      "src etag".ljust(40),
-      "target etag".ljust(40),
+      "src bytes".ljust(12+1),
+      "target bytes".ljust(12+1),
+      "senc".ljust(4+1),
+      "tenc".ljust(4+1),
+      "src etag".ljust(34+1),
+      "target etag".ljust(34+1),
+      "src md5".ljust(24+1),
+      "target md5".ljust(24+1),
       "filename"
     ]
+
     print("".join(header))
     for filename in failed_files:
       sm = src_meta[filename]
       tm = target_meta[filename]
-      print(f'{sm["Content-Length"]:<15}\t{tm["Content-Length"]:<15}\t{sm["ETag"] or "None":<34}\t{tm["ETag"] or "None":<34}\t{filename}')
+      print(f'{sm["Content-Length"]:<12} {tm["Content-Length"]:<12} {sm["Content-Encoding"] or "None":<4} {tm["Content-Encoding"] or "None":<4} {sm["ETag"] or "None":<34} {tm["ETag"] or "None":<34} {sm["Content-Md5"] or "None":<24} {tm["Content-Md5"] or "None":<24} {filename}')
     print("--")
 
   print(red(f"failed. {len(failed_files)} failed. {len(matching_files) - len(failed_files)} succeeded."))

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -463,7 +463,7 @@ def populate_md5(cf, metadata, threshold=1e9):
 @click.argument("target")
 @click.option('-m', '--only-matching', is_flag=True, default=False, help="Only check files with matching filenames.", show_default=True)
 @click.option('-v', '--verbose', is_flag=True, default=False, help="Output detailed information of failed matches.", show_default=True)
-@click.option('--md5', is_flag=True, default=False, help="Compute the md5 hash if the Etag is missing.", show_default=True)
+@click.option('--md5', is_flag=True, default=False, help="Compute the md5 hash if the Etag is missing. Can be slow!", show_default=True)
 def verify(source, target, only_matching, verbose, md5):
   """
   Validates that the checksums of two files

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -434,9 +434,10 @@ def populate_md5(cf, metadata, threshold=1e9):
   """threshold: parallel download up to this many bytes of files at once"""
   sz = lambda fname: metadata[fname]["Content-Length"]
   etag = lambda fname: metadata[fname]["ETag"] 
+  md5content = lambda fname: metadata[fname]["Content-Md5"]
 
   filenames = list(metadata.keys())
-  filenames = [ fname for fname in filenames if not etag(fname) ]
+  filenames = [ fname for fname in filenames if not etag(fname) and not md5content(fname) ]
 
   while filenames:
     filename = filenames.pop()

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -449,7 +449,7 @@ def populate_md5(cf, metadata, threshold=1e9):
       paths.append( filenames.pop() )
       size += sz(paths[-1])
 
-    results = cf.get(paths)
+    results = cf.get(paths, raw=True)
     for result in results: 
       filename = result["path"]
       metadata[filename]["ETag"] = cloudfiles.lib.md5(result["content"], base=64)


### PR DESCRIPTION
Tool to help check if transfers completed successfully.

Compare two directories list of files to see if the content length matches, then ETag, then Content-Md5. Performs comparison based on matching filenames. By default, returns an error if the directories don't match, but you can also force it to do a comparison of the intersection of the two directories.

Example:
```
cloudfiles verify gs://bucket/files s3://bucket/files --verbose
```

The filesystem doesn't store ETags or md5 hashes, so we add an option to compute it on the fly:

```
cloudfiles verify ./mydata gs://bucket/copy-of-my-data/ --md5
```

CloudFiles checks md5 during downloads and uploads, but this feature gives users more confidence when they can see everything matches.

