### PR TITLE
feat: s3 aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ cloudfiles ls -e "gs://bucket/prefix[ab]"
 # cloudfiles ls gs://bucket/prefixb
 ```
 
+### `alias` for Alternative S3 Endpoints
+
+You can set your own protocols for S3 compatible endpoints by creating dynamic or persistent aliases. CloudFiles comes with two official s3 endpoints that are important for the Seung Lab, `matrix://` and `tigerdata://` which point to Princeton S3 endpoints. Official aliases can't be overridden.
+
+To create a dynamic alias, you can use `cloudfiles.paths.add_alias` which will only affect the current process. To create a persistent alias that resides in `~/.cloudfiles/aliases.json`, you can use the CLI. 
+
+```bash
+cloudfiles alias add example s3://https://example.com/ # example://
+cloudfiles alias ls # list all aliases
+cloudfiles alias rm example # remove example://
+```
+
+The alias file is only accessed (and cached) if CloudFiles encounters an unknown protocol. If you stick to default protocols and use the syntax `s3://https://example.com/` for alternative endpoints, you can still use CloudFiles in environments without filesystem access.
+
 ## Credits
 
 CloudFiles is derived from the [CloudVolume.Storage](https://github.com/seung-lab/cloud-volume/tree/master/cloudvolume/storage) system.  

--- a/automated_test.py
+++ b/automated_test.py
@@ -651,6 +651,9 @@ def test_to_https_protocol():
   pth = to_https_protocol("matrix://my_bucket/to/heaven")
   assert pth == "https://s3-hpcrc.rc.princeton.edu/my_bucket/to/heaven"
 
+  pth = to_https_protocol("tigerdata://my_bucket/to/heaven")
+  assert pth == "https://tigerdata.princeton.edu/my_bucket/to/heaven"
+
   pth = to_https_protocol("file://my_bucket/to/heaven")
   assert pth == "file://my_bucket/to/heaven"
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -661,7 +661,7 @@ def test_to_https_protocol():
   pth = to_https_protocol("mem://my_bucket/to/heaven")
   assert pth == "mem://my_bucket/to/heaven"
 
-  pth = ExtractedPath('precomputed', 'gs', 'my_bucket', 'to/heaven', None)
+  pth = ExtractedPath('precomputed', 'gs', 'my_bucket', 'to/heaven', None, None)
   pth = to_https_protocol(pth)
   assert pth == extract("https://storage.googleapis.com/my_bucket/to/heaven")
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -667,28 +667,28 @@ def test_to_https_protocol():
 
 def test_ascloudpath():
   from cloudfiles.paths import ascloudpath, ExtractedPath
-  pth = ExtractedPath('precomputed', 'gs', 'my_bucket', 'of/heaven', None)
+  pth = ExtractedPath('precomputed', 'gs', 'my_bucket', 'of/heaven', None, None)
   assert ascloudpath(pth) == "precomputed://gs://my_bucket/of/heaven"
 
-  pth = ExtractedPath(None, 'gs', 'my_bucket', 'of/heaven', None)
+  pth = ExtractedPath(None, 'gs', 'my_bucket', 'of/heaven', None, None)
   assert ascloudpath(pth) == "gs://my_bucket/of/heaven"
 
-  pth = ExtractedPath(None, 'file', 'my_bucket', 'of/heaven', None)
+  pth = ExtractedPath(None, 'file', 'my_bucket', 'of/heaven', None, None)
   assert ascloudpath(pth) == "file://my_bucket/of/heaven"
 
-  pth = ExtractedPath(None, 'mem', 'my_bucket', 'of/heaven', None)
+  pth = ExtractedPath(None, 'mem', 'my_bucket', 'of/heaven', None, None)
   assert ascloudpath(pth) == "mem://my_bucket/of/heaven"
 
-  pth = ExtractedPath(None, 'https', 'my_bucket', 'of/heaven', 'https://some.domain.com')
+  pth = ExtractedPath(None, 'https', 'my_bucket', 'of/heaven', 'https://some.domain.com', None)
   assert ascloudpath(pth) == "https://some.domain.com/my_bucket/of/heaven"
 
-  pth = ExtractedPath('graphene', 'https', 'my_bucket', 'of/heaven', 'https://some.domain.com')
+  pth = ExtractedPath('graphene', 'https', 'my_bucket', 'of/heaven', 'https://some.domain.com', None)
   assert ascloudpath(pth) == "graphene://https://some.domain.com/my_bucket/of/heaven"
 
-  pth = ExtractedPath(None, 's3', 'my_bucket', 'of/heaven', 'https://some.domain.com')
+  pth = ExtractedPath(None, 's3', 'my_bucket', 'of/heaven', 'https://some.domain.com', None)
   assert ascloudpath(pth) == "s3://https://some.domain.com/my_bucket/of/heaven"
 
-  pth = ExtractedPath("precomputed", 's3', 'my_bucket', 'of/heaven', 'https://some.domain.com')
+  pth = ExtractedPath("precomputed", 's3', 'my_bucket', 'of/heaven', 'https://some.domain.com', None)
   assert ascloudpath(pth) == "precomputed://s3://https://some.domain.com/my_bucket/of/heaven"
 
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -420,17 +420,17 @@ def test_path_extraction():
   assert (paths.extract('graphene://http://localhost:8080/segmentation/1.0/testvol')
     == ExtractedPath(
       'graphene', 'http', None, 
-      'segmentation/1.0/testvol', 'http://localhost:8080'))
+      'segmentation/1.0/testvol', 'http://localhost:8080', None))
 
   assert (paths.extract('precomputed://gs://fafb-ffn1-1234567')
     == ExtractedPath(
       'precomputed', 'gs', 'fafb-ffn1-1234567', 
-      '', None))
+      '', None, None))
 
   assert (paths.extract('precomputed://gs://fafb-ffn1-1234567/segmentation')
     == ExtractedPath(
       'precomputed', 'gs', 'fafb-ffn1-1234567', 
-      'segmentation', None))
+      'segmentation', None, None))
 
   firstdir = lambda x: '/' + x.split('/')[1]
 
@@ -446,39 +446,40 @@ def test_path_extraction():
   assert (paths.extract('s3://seunglab-test/intermediate/path/dataset/layer') 
       == ExtractedPath(
         'precomputed', 's3', 'seunglab-test', 
-        'intermediate/path/dataset/layer', None
+        'intermediate/path/dataset/layer', None, None
       ))
 
   assert (paths.extract('file:///tmp/dataset/layer') 
       == ExtractedPath(
         'precomputed', 'file', None, 
-        "/tmp/dataset/layer", None
+        "/tmp/dataset/layer", None, None
       ))
 
   assert (paths.extract('file://seunglab-test/intermediate/path/dataset/layer') 
       == ExtractedPath(
         'precomputed', 'file', None,
-        os.path.join(curpath, 'seunglab-test/intermediate/path/dataset/layer'), None
+        os.path.join(curpath, 'seunglab-test/intermediate/path/dataset/layer'), 
+        None, None
       ))
 
   assert (paths.extract('gs://seunglab-test/intermediate/path/dataset/layer') 
       == ExtractedPath(
         'precomputed', 'gs', 'seunglab-test',
-        'intermediate/path/dataset/layer', None
+        'intermediate/path/dataset/layer', None, None
       ))
 
   assert (paths.extract('file://~/seunglab-test/intermediate/path/dataset/layer') 
       == ExtractedPath(
         'precomputed', 'file', None, 
         os.path.join(homepath, 'seunglab-test/intermediate/path/dataset/layer'),
-        None
+        None, None
       )
   )
 
   assert (paths.extract('file:///User/me/.cloudvolume/cache/gs/bucket/dataset/layer') 
       == ExtractedPath(
         'precomputed', 'file', None, 
-        '/User/me/.cloudvolume/cache/gs/bucket/dataset/layer', None
+        '/User/me/.cloudvolume/cache/gs/bucket/dataset/layer', None, None
       ))
 
   shoulderror('ou3bouqjsa fkj aojsf oaojf ojsaf')
@@ -513,7 +514,7 @@ def test_path_extraction():
   assert (paths.extract('gs://username/a/username2/b/c/d') 
       == ExtractedPath(
         'precomputed', 'gs', 'username', 
-        'a/username2/b/c/d', None
+        'a/username2/b/c/d', None, None
       ))
 
 @pytest.mark.parametrize("protocol", ('mem', 'file', 's3'))

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -31,6 +31,7 @@ from .lib import (
   duplicates, first, sip,
   md5, crc32c, decode_crc32c_b64
 )
+from .paths import ALIASES
 from .threaded_queue import ThreadedQueue, DEFAULT_THREADS
 from .typing import (
   CompressType, GetPathType, PutScalarType,
@@ -48,11 +49,12 @@ INTERFACES = {
   'file': FileInterface,
   'gs': GoogleCloudStorageInterface,
   's3': S3Interface,
-  'matrix': S3Interface,
   'http': HttpInterface,
   'https': HttpInterface,
   'mem': MemoryInterface,
 }
+for alias in ALIASES:
+  INTERFACES[alias] = S3Interface
 
 def parallelize(desc=None, returns_list=False):
   """

--- a/cloudfiles/connectionpools.py
+++ b/cloudfiles/connectionpools.py
@@ -110,16 +110,13 @@ class S3ConnectionPool(ConnectionPool):
     if endpoint is not None:
       additional_args['endpoint_url'] = endpoint
 
-    if self.service in ('aws', 's3'):
-      return boto3.client(
-        's3',
-        aws_access_key_id=secrets['AWS_ACCESS_KEY_ID'],
-        aws_secret_access_key=secrets['AWS_SECRET_ACCESS_KEY'],
-        region_name=secrets.get('AWS_DEFAULT_REGION', 'us-east-1'),
-        **additional_args
-      )
-    else:
-      raise UnsupportedProtocolError(f"{self.service} service unknown.")
+    return boto3.client(
+      's3',
+      aws_access_key_id=secrets['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key=secrets['AWS_SECRET_ACCESS_KEY'],
+      region_name=secrets.get('AWS_DEFAULT_REGION', 'us-east-1'),
+      **additional_args
+    )
       
   def close(self, conn):
     try:

--- a/cloudfiles/connectionpools.py
+++ b/cloudfiles/connectionpools.py
@@ -112,8 +112,8 @@ class S3ConnectionPool(ConnectionPool):
 
     return boto3.client(
       's3',
-      aws_access_key_id=secrets['AWS_ACCESS_KEY_ID'],
-      aws_secret_access_key=secrets['AWS_SECRET_ACCESS_KEY'],
+      aws_access_key_id=secrets.get('AWS_ACCESS_KEY_ID', None),
+      aws_secret_access_key=secrets.get('AWS_SECRET_ACCESS_KEY', None),
       region_name=secrets.get('AWS_DEFAULT_REGION', 'us-east-1'),
       **additional_args
     )
@@ -123,7 +123,6 @@ class S3ConnectionPool(ConnectionPool):
       return conn.close()
     except AttributeError:
       pass # AttributeError: 'S3' object has no attribute 'close' on shutdown
-
 
 class GCloudBucketPool(ConnectionPool):
   def __init__(self, bucket, request_payer=None):

--- a/cloudfiles/connectionpools.py
+++ b/cloudfiles/connectionpools.py
@@ -118,15 +118,8 @@ class S3ConnectionPool(ConnectionPool):
         region_name=secrets.get('AWS_DEFAULT_REGION', 'us-east-1'),
         **additional_args
       )
-    elif self.service == 'matrix':
-      return boto3.client(
-        's3',
-        aws_access_key_id=secrets['AWS_ACCESS_KEY_ID'],
-        aws_secret_access_key=secrets['AWS_SECRET_ACCESS_KEY'],
-        endpoint_url='https://s3-hpcrc.rc.princeton.edu',
-      )
     else:
-      raise UnsupportedProtocolError("{} unknown. Choose from 's3' or 'matrix'.", self.service)
+      raise UnsupportedProtocolError(f"{self.service} service unknown.")
       
   def close(self, conn):
     try:

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -36,6 +36,10 @@ S3_POOL = None
 GC_POOL = None
 MEM_POOL = None
 
+S3_ACLS = {
+  "tigerdata": "private",
+}
+
 S3ConnectionPoolParams = namedtuple('S3ConnectionPoolParams', 'service bucket_name request_payer')
 GCloudBucketPoolParams = namedtuple('GCloudBucketPoolParams', 'bucket_name request_payer')
 MemoryPoolParams = namedtuple('MemoryPoolParams', 'bucket_name')
@@ -637,7 +641,7 @@ class S3Interface(StorageInterface):
 
     self._request_payer = request_payer
     self._path = path
-    
+
     service = path.alias or 's3'
     self._conn = S3_POOL[S3ConnectionPoolParams(service, path.bucket, request_payer)].get_connection(secrets, path.host)
 
@@ -649,7 +653,6 @@ class S3Interface(StorageInterface):
     self, file_path, content, 
     content_type, compress, 
     cache_control=None,
-    ACL="bucket-owner-full-control",
     storage_class=None
   ):
     key = self.get_path_to_file(file_path)
@@ -659,7 +662,7 @@ class S3Interface(StorageInterface):
       'Body': content,
       'Key': key,
       'ContentType': (content_type or 'application/octet-stream'),
-      'ACL': ACL,
+      'ACL': S3_ACLS.get(self._path.alias, "bucket-owner-full-control"),
       'ContentMD5': md5(content),
       **self._additional_attrs,
     }

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -637,7 +637,9 @@ class S3Interface(StorageInterface):
 
     self._request_payer = request_payer
     self._path = path
-    self._conn = S3_POOL[S3ConnectionPoolParams(path.protocol, path.bucket, request_payer)].get_connection(secrets, path.host)
+    
+    service = path.alias or 's3'
+    self._conn = S3_POOL[S3ConnectionPoolParams(service, path.bucket, request_payer)].get_connection(secrets, path.host)
 
   def get_path_to_file(self, file_path):
     return posixpath.join(self._path.path, file_path)

--- a/cloudfiles/paths.py
+++ b/cloudfiles/paths.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-import json
+import orjson
 import os.path
 import posixpath
 import re
@@ -38,7 +38,7 @@ def update_aliases_from_file():
   aliases = {}
   if os.path.exists(ALIAS_FILE):
     with open(ALIAS_FILE, "rt") as f:
-      aliases = json.loads(f.read())
+      aliases = orjson.loads(f.read())
 
   ALIASES_FROM_FILE = aliases
 

--- a/cloudfiles/paths.py
+++ b/cloudfiles/paths.py
@@ -12,23 +12,31 @@ ExtractedPath = namedtuple('ExtractedPath',
   ('format', 'protocol', 'bucket', 'path', 'host')
 )
 
-ALLOWED_PROTOCOLS = [ 'gs', 'file', 's3', 'matrix', 'http', 'https', 'mem' ]
+ALIASES = {}
+BASE_ALLOWED_PROTOCOLS = [ 
+  'gs', 'file', 's3', 'matrix', 
+  'http', 'https', 'mem' 
+]
+ALLOWED_PROTOCOLS = list(BASE_ALLOWED_PROTOCOLS)
 ALLOWED_FORMATS = [ 'graphene', 'precomputed', 'boss' ] 
 
-CLOUDPATH_ERROR = yellow("""
-Cloud Path must conform to [FORMAT://]PROTOCOL://PATH
-Examples: 
-  precomputed://gs://test_bucket/em
-  gs://test_bucket/em
-  graphene://https://example.com/image/em
+def cloudpath_error(cloudpath):
+  return yellow("""
+    Cloud Path must conform to [FORMAT://]PROTOCOL://PATH
+    Examples: 
+      precomputed://gs://test_bucket/em
+      gs://test_bucket/em
+      graphene://https://example.com/image/em
 
-Supported Formats: None (precomputed), {}
-Supported Protocols: {}
+    Supported Formats: None (precomputed), {}
+    Supported Protocols: {}
 
-Cloud Path Recieved: {}
-""").format(
-  ", ".join(ALLOWED_FORMATS), ", ".join(ALLOWED_PROTOCOLS), '{}' # curry first two
-)
+    Cloud Path Recieved: {}
+  """).format(
+    ", ".join(ALLOWED_FORMATS), 
+    ", ".join(ALLOWED_PROTOCOLS), 
+    cloudpath
+  )
 
 def mkregexp():
   fmt_capture = r'|'.join(ALLOWED_FORMATS)
@@ -40,16 +48,56 @@ def mkregexp():
 
 CLOUDPATH_REGEXP = re.compile(mkregexp())
 
+def add_alias(alias:str, host:str):
+  global ALIASES
+  global ALLOWED_PROTOCOLS
+  global BASE_ALLOWED_PROTOCOLS
+  global CLOUDPATH_REGEXP
+
+  if host[-1] != '/':
+    host += '/'
+
+  ALIASES[alias] = host
+  ALLOWED_PROTOCOLS = BASE_ALLOWED_PROTOCOLS + list(ALIASES.keys())
+  CLOUDPATH_REGEXP = re.compile(mkregexp())
+
+def remove_alias(alias:str):
+  global ALIASES
+  global ALLOWED_PROTOCOLS
+  global BASE_ALLOWED_PROTOCOLS
+  global CLOUDPATH_REGEXP
+
+  del ALIASES[alias]
+  ALLOWED_PROTOCOLS = BASE_ALLOWED_PROTOCOLS + list(ALIASES.keys())
+  CLOUDPATH_REGEXP = re.compile(mkregexp())  
+
+def resolve_alias(cloudpath:str) -> str:
+  proto = get_protocol(cloudpath)
+  if proto not in ALIASES:
+    return cloudpath
+
+  return cloudpath.replace(f"{proto}://", ALIASES[proto], 1)
+
+## OFFICAL ALIASES
+
+add_alias("matrix", "s3://https://s3-hpcrc.rc.princeton.edu/")
+add_alias("tigerdata", "s3://https://tigerdata.princeton.edu/")
+
+## Other Path Library Functions
+
 def normalize(path):
   proto = get_protocol(path)
   if proto is None:
     proto = "file"
     path = toabs(path)
     return f"file://{path}"
-
   return path
 
-def get_protocol(cloudpath):
+def get_any_protocol(cloudpath):
+  """
+  Get the string in the protocol position even
+  if its not a valid one.
+  """
   protocol_re = re.compile(r'(?P<proto>\w+)://')
   match = re.match(protocol_re, cloudpath)
   if not match:
@@ -124,8 +172,10 @@ def pop_protocol(cloudpath):
 
   return (protocol, cloudpath)
 
-def extract_format_protocol(cloudpath):
-  error = UnsupportedProtocolError(CLOUDPATH_ERROR.format(cloudpath))
+def extract_format_protocol(cloudpath:str) -> tuple:
+  error = UnsupportedProtocolError(cloudpath_error(cloudpath))
+
+  cloudpath = resolve_alias(cloudpath)
 
   m = re.match(CLOUDPATH_REGEXP, cloudpath)
   if m is None:
@@ -154,7 +204,7 @@ def extract_format_protocol(cloudpath):
 
   return (fmt, proto, endpoint, cloudpath)
 
-def extract(cloudpath, windows=None):
+def extract(cloudpath:str, windows=None) -> ExtractedPath:
   """
   Given a valid cloudpath of the form 
   format://protocol://bucket/.../dataset/layer
@@ -174,7 +224,7 @@ def extract(cloudpath, windows=None):
     return ExtractedPath('','','','','')
 
   bucket_re = re.compile(r'^(/?[~\d\w_\.\-]+(?::\d+)?)(?:/|$)') # posix /what/a/great/path  
-  error = UnsupportedProtocolError(CLOUDPATH_ERROR.format(cloudpath))
+  error = UnsupportedProtocolError(cloudpath_error(cloudpath))
 
   fmt, protocol, host, cloudpath = extract_format_protocol(cloudpath)
 
@@ -214,9 +264,12 @@ def to_https_protocol(cloudpath):
     return cloudpath
 
   if "s3://http://" in cloudpath or "s3://https://" in cloudpath:
-    return cloudpath
+    return cloudpath.replace("s3://", "", 1)
 
   cloudpath = cloudpath.replace("gs://", "https://storage.googleapis.com/", 1)
   cloudpath = cloudpath.replace("s3://", "https://s3.amazonaws.com/", 1)
-  cloudpath = cloudpath.replace("matrix://", "https://s3-hpcrc.rc.princeton.edu/", 1)
-  return cloudpath
+
+  for alias, host in ALIASES.items():
+    cloudpath = cloudpath.replace(f"{alias}://", host, 1)
+
+  return cloudpath.replace("s3://", "", 1)


### PR DESCRIPTION
This allows us to soft(er)-code `matrix://` and `tigerdata://` but also allows end-users to add their own aliases dynamically.

Persistent aliases can be added, listed, and removed via the command line which will be saved in ~/.cloudfiles/aliases.json. The file will only be accessed once (per process) if an unknown protocol is encountered.