### PR TITLE
fix(S3Interface): release_connection respects alias

### DIFF
--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -918,4 +918,5 @@ class S3Interface(StorageInterface):
 
   def release_connection(self):
     global S3_POOL
-    S3_POOL[S3ConnectionPoolParams(self._path.protocol, self._path.bucket, self._request_payer)].release_connection(self._conn)
+    service = self._path.alias or 's3'
+    S3_POOL[S3ConnectionPoolParams(service, self._path.bucket, self._request_payer)].release_connection(self._conn)


### PR DESCRIPTION
Connections were opened using aliases, such as `matrix`, but release_connection looked for `s3`. This should reduce the number of open connections at least to pre-alias levels.