### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ requests>=2.22.0
 six>=1.14.0
 tenacity>=4.10.0
 tqdm
-urllib3[secure]>=1.26.3
+urllib3>=1.26.3
 zstandard
 rsa>=4.7.2


### PR DESCRIPTION
### Description

pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680

uremoved urllib3[secure] extra updated with urllib3