### PR TITLE
feat: support for GCS composite uploads

### DIFF
--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -600,6 +600,7 @@ class CloudFiles:
         part_size=int(1e8),
         secrets=self.secrets,
         content_type=content_type,
+        progress=self.progress,
       )
 
     return self.puts({
@@ -1046,7 +1047,11 @@ class CloudFile:
   def put(self, content:bytes, *args, **kwargs):
     """Upload a file."""
     res = self.cf.put(self.filename, content, *args, **kwargs)
-    self._size = len(content)
+    if hasattr(content, "__len__"):
+      self._size = len(content)
+    else:
+      content.seek(0, os.SEEK_END)
+      self._size = content.tell()
     return res
 
   def put_json(self, content, *args, **kwargs):

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -540,7 +540,7 @@ class CloudFiles:
         self.protocol == "gs" 
         and (
           (hasattr(content, "read") and hasattr(content, "seek"))
-          or len(content) > self.composite_upload_threshold
+          or (hasattr(content, "__len__") and len(content) > self.composite_upload_threshold)
         )
       ):
         gcs.composite_upload(
@@ -973,7 +973,7 @@ class CloudFiles:
           for download in downloaded:
             download["path"] = posixpath.sep.join(download["path"].split(os.path.sep))
 
-        self.puts(downloaded, raw=True, progress=False)
+        self.puts(downloaded, raw=True, progress=False, compress=reencode)
         pbar.update(len(block_paths))
 
   def join(self, *paths:str) -> str:

--- a/cloudfiles/gcs.py
+++ b/cloudfiles/gcs.py
@@ -1,28 +1,70 @@
 """
-
+Specialized logic for performing composite parallel uploads
+to GCS.
 """
-from typing import BinaryIO, Optional
+from typing import Union, BinaryIO, Optional
 
-import os
+import io
 import math
+import os
 import posixpath
 
 from google.cloud.storage import Client
 from google.oauth2 import service_account
 
 from . import paths
+from .lib import sip
 from .secrets import google_credentials
+from .typing import SecretsType
 
 MAX_COMPOSITE_PARTS = 32 # google specified restriction
 
+def merge(cf, bucket, path, depth, max_depth, num_parts, content_type):
+  subpath = posixpath.dirname(path.path)
+  base_key = posixpath.basename(path.path)
+
+  names = [ f"{base_key}.{depth}.{i}.part" for i in range(num_parts) ]
+
+  i = 0
+  for subnames in sip(names, MAX_COMPOSITE_PARTS):
+    if depth == max_depth:
+      node_name = base_key
+    else:
+      node_name = f"{base_key}.{depth+1}.{i}.part"
+
+    node_name = posixpath.join(subpath, node_name)
+    i += 1
+
+    destination = bucket.blob(node_name)
+    if content_type:
+      destination.content_type = content_type
+
+    destination.compose(
+      [ bucket.blob(posixpath.join(subpath, key)) for key in subnames ]
+    )
+
+    cf.delete(subnames)
+
+  if depth < max_depth:
+    merge(
+      cf, bucket, path, 
+      depth+1, max_depth, 
+      int(math.ceil(num_parts / MAX_COMPOSITE_PARTS)), 
+      content_type
+    )
+
 def composite_upload(
   cloudpath:str, 
-  handle:BinaryIO,
+  handle:Union[BinaryIO,bytes],
   part_size:int = int(1e8),
+  secrets:SecretsType = None,
   content_type:Optional[str] = None
 ) -> int:
-  from .cloudfiles import CloudFiles
+  from .cloudfiles import CloudFiles, CloudFile
   
+  if isinstance(handle, bytes):
+    handle = io.BytesIO(handle)
+
   path = paths.extract(cloudpath)
 
   handle.seek(0, os.SEEK_END)
@@ -31,9 +73,6 @@ def composite_upload(
 
   num_parts = int(math.ceil(file_size / part_size))
 
-  if num_parts > MAX_COMPOSITE_PARTS:
-    raise ValueError(f"file size {file_size} not supported yet")
-
   cur = 0
   parts = []
   while cur < file_size:
@@ -41,18 +80,27 @@ def composite_upload(
     cur += len(binary)
     parts.append(binary)
 
-  cf = CloudFiles(posixpath.dirname(cloudpath))
+  if len(parts) == 1:
+    CloudFile(cloudpath, secrets=secrets).put(
+      parts[0], content_type=content_type
+    )
+    return 1
+
+  cf = CloudFiles(posixpath.dirname(cloudpath), secrets=secrets)
   base_key = posixpath.basename(cloudpath)
 
   parts = [ 
-    (f"{base_key}.{i}.part", binary)  
+    (f"{base_key}.0.{i}.part", binary)  
     for i, binary in enumerate(parts)
   ] 
 
   cf.puts(parts)
-  names = [ name for name, binary in parts ]
 
+  tree_depth = int(math.ceil(math.log2(num_parts) / math.log2(MAX_COMPOSITE_PARTS)))
+  
   project, credentials = google_credentials(path.bucket)
+  if secrets:
+    credentials = secrets
 
   client = Client(
     credentials=credentials,
@@ -60,16 +108,11 @@ def composite_upload(
   )
   bucket = client.bucket(path.bucket)
 
-  subpath = posixpath.dirname(path.path)
-  destination = bucket.blob(posixpath.join(subpath, base_key))
-  if content_type:
-    destination.content_type = content_type
-
-  destination.compose(
-    [ bucket.blob(posixpath.join(subpath, key)) for key in names ]
+  merge(
+    cf, bucket, path, 
+    0, tree_depth - 1, num_parts, 
+    content_type
   )
-
-  cf.delete(names)
 
   return 1
 

--- a/cloudfiles/gcs.py
+++ b/cloudfiles/gcs.py
@@ -1,0 +1,76 @@
+"""
+
+"""
+from typing import BinaryIO, Optional
+
+import os
+import math
+import posixpath
+
+from google.cloud.storage import Client
+from google.oauth2 import service_account
+
+from . import paths
+from .secrets import google_credentials
+
+MAX_COMPOSITE_PARTS = 32 # google specified restriction
+
+def composite_upload(
+  cloudpath:str, 
+  handle:BinaryIO,
+  part_size:int = int(1e8),
+  content_type:Optional[str] = None
+) -> int:
+  from .cloudfiles import CloudFiles
+  
+  path = paths.extract(cloudpath)
+
+  handle.seek(0, os.SEEK_END)
+  file_size = handle.tell()
+  handle.seek(0, os.SEEK_SET)
+
+  num_parts = int(math.ceil(file_size / part_size))
+
+  if num_parts > MAX_COMPOSITE_PARTS:
+    raise ValueError(f"file size {file_size} not supported yet")
+
+  cur = 0
+  parts = []
+  while cur < file_size:
+    binary = handle.read(part_size)
+    cur += len(binary)
+    parts.append(binary)
+
+  cf = CloudFiles(posixpath.dirname(cloudpath))
+  base_key = posixpath.basename(cloudpath)
+
+  parts = [ 
+    (f"{base_key}.{i}.part", binary)  
+    for i, binary in enumerate(parts)
+  ] 
+
+  cf.puts(parts)
+  names = [ name for name, binary in parts ]
+
+  project, credentials = google_credentials(path.bucket)
+
+  client = Client(
+    credentials=credentials,
+    project=project,
+  )
+  bucket = client.bucket(path.bucket)
+
+  subpath = posixpath.dirname(path.path)
+  destination = bucket.blob(posixpath.join(subpath, base_key))
+  if content_type:
+    destination.content_type = content_type
+
+  destination.compose(
+    [ bucket.blob(posixpath.join(subpath, key)) for key in names ]
+  )
+
+  cf.delete(names)
+
+  return 1
+
+  

--- a/cloudfiles/gcs.py
+++ b/cloudfiles/gcs.py
@@ -10,7 +10,6 @@ import os
 import posixpath
 
 from google.cloud.storage import Client
-from google.oauth2 import service_account
 
 from . import paths
 from .lib import sip

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -13,6 +13,7 @@ from glob import glob
 import google.cloud.exceptions
 from google.cloud.storage import Batch, Client
 import requests
+import shutil
 import tenacity
 
 from .compression import COMPRESSION_TYPES
@@ -112,6 +113,11 @@ class FileInterface(StorageInterface):
       and type(content) is str:
 
       content = content.encode('utf-8')
+
+    if hasattr(content, "read") and hasattr(content, "seek"):
+      with open(path, 'wb') as f:
+        shutil.copyfileobj(content, f)
+      return
 
     try:
       with open(path, 'wb') as f:

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -153,7 +153,7 @@ def crc32c(binary):
   Computes the crc32c of a binary string 
   and returns it as an integer.
   """
-  return crc32clib.value(binary) # an integer
+  return crc32clib.crc32c(binary) # an integer
 
 def md5(binary, base=64):
   """

--- a/cloudfiles/typing.py
+++ b/cloudfiles/typing.py
@@ -1,14 +1,15 @@
 from typing import (
   Any, Dict, Optional, 
   Union, Tuple,  
-  Iterable, TypeVar
+  Iterable, TypeVar,
+  BinaryIO
 )
 
 T = TypeVar('T')
 ScalarOrIterable = Union[T, Iterable[T]]
 CompressType = Optional[Union[str,bool]]
 GetPathType = ScalarOrIterable[str]
-PutScalarType = Union[Tuple[str,bytes], Dict[str,Any]]
+PutScalarType = Union[Tuple[str,Union[BinaryIO,bytes]], Dict[str,Any]]
 PutType = ScalarOrIterable[PutScalarType]
 ParallelType = Union[int,bool]
 SecretsType = Optional[Union[str,dict]]

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -295,14 +295,14 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
       shutil.copyfile(nsrc.replace("file://", ""), ndest.replace("file://", ""))
       return
     
-    downloaded = cfsrc.get(xferpaths, raw=True)
+    downloaded = cfsrc.get([ xferpaths ], raw=True)
     if compression is not None:
-      downloaded = transcode(downloaded, compression, in_place=True)
+      downloaded = next(transcode(downloaded, compression, in_place=True))
     
     if isdestdir:
-      cfdest.put(os.path.basename(nsrc), downloaded, raw=True)
+      cfdest.put(os.path.basename(nsrc), downloaded["content"], raw=True, compress=compression)
     else:
-      cfdest.put(os.path.basename(ndest), downloaded, raw=True)
+      cfdest.put(os.path.basename(ndest), downloaded["content"], raw=True, compress=compression)
 
 def _cp(src, dst, compression, progress, block_size, paths):
   cfsrc = CloudFiles(src, green=True, progress=progress)

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -284,6 +284,7 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
 
     cfdest = CloudFiles(destpath, green=True, progress=progress)
 
+    # high performance local copy
     if (
       cfsrc.protocol == "file" 
       and cfdest.protocol == "file" 

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -9,6 +9,7 @@ import posixpath
 import pprint
 import os.path
 from tqdm import tqdm
+import shutil
 import sys
 
 # Below two lines fix MacOS warning on 
@@ -280,12 +281,21 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
     if use_stdout:
       _cp_stdout(srcpath, xferpaths)
       return
+
+    cfdest = CloudFiles(destpath, green=True, progress=progress)
+
+    if (
+      cfsrc.protocol == "file" 
+      and cfdest.protocol == "file" 
+      and compression is None
+    ):
+      shutil.copyfile(nsrc.replace("file://", ""), ndest.replace("file://", ""))
+      return
     
     downloaded = cfsrc.get(xferpaths, raw=True)
     if compression is not None:
       downloaded = transcode(downloaded, compression, in_place=True)
-
-    cfdest = CloudFiles(destpath, green=True, progress=progress)
+    
     if isdestdir:
       cfdest.put(os.path.basename(nsrc), downloaded, raw=True)
     else:

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -289,6 +289,8 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
       and cfdest.protocol == "file" 
       and compression is None
     ):
+      if isdestdir:
+        ndest = os.path.join(ndest, os.path.basename(nsrc))
       shutil.copyfile(nsrc.replace("file://", ""), ndest.replace("file://", ""))
       return
     


### PR DESCRIPTION
Transparently handles large uploads (>=100MB) on GCS by using the composite upload feature. This splits uploads into 100MB parts and then merges them 32 parts at a time recursively. The smaller part files are deleted.

Part format: `filename.{depth}.{partno}.part`

A few other goodies are added here:
- Faster local file transfers
- FileInterface also accepts a file handle
- Fixes broken transcoding for single files on CLI
- Transfers of compressed files from GCS to local fs will get a compression suffix
