### PR TITLE
perf: better memory usage for file to gs/s3 transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ CloudFiles was developed to access files from object storage without ever touchi
 8. High speed gzip decompression using libdeflate (compared with zlib).
 9. Bundled CLI tool.
 10. Accepts iterator and generator input.
-11. Resumable transfers.
+11. Resumable bulk transfers.
 12. Supports composite parallel upload for GCS and multi-part upload for AWS S3.
+13. Supports s3 and GCS internal copies to avoid unnecessary data movement.
 
 ## Installation 
 
@@ -412,9 +413,8 @@ For the cp command, the bundled CLI tool has a number of advantages vs. `gsutil`
 
 It also has some disadvantages:  
 
-1. gs:// to gs:// transfers are looped through the executing machine.
-2. Doesn't support all commands.
-3. File suffixes may be added to signify compression type on the local filesystem (e.g. `.gz`, `.br`, or `.zstd`). `cloudfiles ls` will list them without the extension and they will be converted into `Content-Encoding` on cloud storage.
+1. Doesn't support all commands.
+2. File suffixes may be added to signify compression type on the local filesystem (e.g. `.gz`, `.br`, or `.zstd`). `cloudfiles ls` will list them without the extension and they will be converted into `Content-Encoding` on cloud storage.
 
 ### `ls` Generative Expressions
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ from cloudfiles import CloudFiles
 
 cf = CloudFiles(
     cloudpath, progress=False, 
-    green=False, secrets=None, num_threads=20,
-    use_https=False, endpoint=None, request_payer=None
+    green=None, secrets=None, num_threads=20,
+    use_https=False, endpoint=None, request_payer=None,
+    composite_upload_threshold = int(1e8)
 )
 
 # cloudpath examples:
@@ -146,7 +147,7 @@ cf = CloudFiles('https://website.com/coolguy/') # arbitrary web server
 
 * cloudpath: The path to the bucket you are accessing. The path is formatted as `$PROTOCOL://BUCKET/PATH`. Files will then be accessed relative to the path. The protocols supported are `gs` (GCS), `s3` (AWS S3), `file` (local FS), `mem` (RAM), and `http`/`https`.
 * progress: Whether to display a progress bar when processing multiple items simultaneously.
-* green: Use green threads. For this to work properly, you must uncomment the top two lines.
+* green: Use green threads. For this to work properly, you must uncomment the top two lines. Green threads are used automatically upon monkey patching if green is None.
 * secrets: Provide secrets dynamically rather than fetching from the credentials directory `$HOME/.cloudvolume/secrets`.
 * num_threads: Number of simultaneous requests to make. Usually 20 per core is pretty close to optimal unless file sizes are extreme.
 * use_https: `gs://` and `s3://` require credentials to access their files. However, each has a read-only https endpoint that sometimes requires no credentials. If True, automatically convert `gs://` to `https://storage.googleapis.com/` and `s3://` to `https://s3.amazonaws.com/`.
@@ -300,6 +301,8 @@ cfg[:] = cff # default block size 64
 ```
 
 Transfer semantics provide a simple way to perform bulk file transfers. Use the `block_size` parameter to adjust the number of files handled in a given pass. This can be important for preventing memory blow-up and reducing latency between batches.
+
+gs to gs and s3 to s3 transfers will occur within the cloud without looping through the executing client provided no reencoding is specified.
 
 #### resumable transfer
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -592,8 +592,8 @@ def test_s3_custom_endpoint_path():
   assert extract.host == 'https://s3-hpcrc.rc.princeton.edu'
 
 @pytest.mark.parametrize('compression', (None, 'gzip', 'br', 'zstd', 'xz', 'bz2'))
-@pytest.mark.parametrize('src_protocol', ( 'file', 's3'))
-@pytest.mark.parametrize('dest_protocol', ( 'file', 's3'))
+@pytest.mark.parametrize('src_protocol', ['mem', 'file', 's3'])
+@pytest.mark.parametrize('dest_protocol', ['mem', 'file', 's3'])
 def test_transfer_semantics(s3, compression, src_protocol, dest_protocol):
   from cloudfiles import CloudFiles, exceptions
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1,6 +1,3 @@
-import gevent.monkey
-gevent.monkey.patch_all(thread=False)
-
 import os
 import pytest
 import re

--- a/automated_test.py
+++ b/automated_test.py
@@ -598,12 +598,18 @@ def test_transfer_semantics(s3, compression, src_protocol, dest_protocol):
   from cloudfiles import CloudFiles, exceptions
 
   if src_protocol == "file":
-    path = '/tmp/cloudfiles/xfer'
+    path = '/tmp/cloudfiles_src/xfer'
   else:
     path = "cloudfiles_src/xfer"
+
+  if dest_protocol == "file":
+    dest_path = "/tmp/cloudfiles_dest/xfer"
+  else:
+    dest_path = "cloudfiles_dest/xfer"
+
   rmtree(path)
   cff = CloudFiles(f'{src_protocol}://{path}')
-  cfm = CloudFiles(f'{dest_protocol}://cloudfiles_dest/xfer')
+  cfm = CloudFiles(f'{dest_protocol}://{dest_path}')
   
   N = 128
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -995,11 +995,13 @@ class CloudFiles:
           downloaded = cf_src.get(block_paths, raw=True, progress=False)
           if reencode is not None:
             downloaded = compression.transcode(downloaded, reencode, in_place=True)
-          for item in downloaded:
-            if "dest_path" in item:
-              item["path"] = item["dest_path"]
-              del item["dest_path"]
-          self.puts(downloaded, raw=True, progress=False, compress=reencode)
+          def renameiter():
+            for item in downloaded:
+              if "dest_path" in item:
+                item["path"] = item["dest_path"]
+                del item["dest_path"]
+              yield item
+          self.puts(renameiter(), raw=True, progress=False, compress=reencode)
           pbar.update(len(block_paths))
 
   def __transfer_file_to_file(

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -919,8 +919,8 @@ class CloudFiles:
       an iterable, transfer only these files.
 
       A path is an iterable that contains str, dict, tuple, or list
-      elements. If dict, by adding the "dest_path" key to "tags", you 
-      can rename objects being copied. With tuple or list, the first
+      elements. If dict, by adding the "dest_path" key, you can 
+      rename objects being copied. With tuple or list, the first
       element of the pair is the source key, the second element
       is the destination key.
 
@@ -963,8 +963,8 @@ class CloudFiles:
       an iterable, transfer only these files.
 
       A path is an iterable that contains str, dict, tuple, or list
-      elements. If dict, by adding the "dest_path" key to "tags", you 
-      can rename objects being copied. With tuple or list, the first
+      elements. If dict, by adding the "dest_path" key, you can 
+      rename objects being copied. With tuple or list, the first
       element of the pair is the source key, the second element
       is the destination key.
 
@@ -1013,6 +1013,10 @@ class CloudFiles:
         self.__transfer_cloud_internal(cf_src, self, paths, total, pbar, block_size)
       else:
         for block_paths in sip(paths, block_size):
+          for path in block_paths:
+            if isinstance(path, dict):
+              if "dest_path" in path:
+                path["tags"] = { "dest_path": dest_path }
           downloaded = cf_src.get(block_paths, raw=True, progress=False)
           if reencode is not None:
             downloaded = compression.transcode(downloaded, reencode, in_place=True)

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -755,6 +755,7 @@ class CloudFiles:
       progress=False,
       concurrency=self.num_threads,
       green=self.green,
+      total=total,
     )
     pbar.close()
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -981,7 +981,11 @@ class CloudFiles:
       elif (
         (
           (cf_src.protocol == "gs" and self.protocol == "gs")
-          or (cf_src.protocol == "s3" and self.protocol == "s3")
+          or (
+            cf_src.protocol == "s3" and self.protocol == "s3"
+            and cf_src._path.host == self._path.host
+            and cf_src._path.alias == self._path.alias
+          )
         )
         and reencode is None
       ):

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -245,7 +245,7 @@ class CloudFiles:
   """
   def __init__(
     self, cloudpath:str, progress:bool = False, 
-    green:bool = False, secrets:SecretsType = None, num_threads:int = 20,
+    green:Optional[bool] = None, secrets:SecretsType = None, num_threads:int = 20,
     use_https:bool = False, endpoint:Optional[str] = None, 
     parallel:ParallelType = 1, request_payer:Optional[str] = None,
     composite_upload_threshold:int = int(1e8)
@@ -257,7 +257,7 @@ class CloudFiles:
     self.progress = progress
     self.secrets = secrets
     self.num_threads = num_threads
-    self.green = bool(green)
+    self.green = green
     self.parallel = int(parallel)
     self.request_payer = request_payer
     self.composite_upload_threshold = composite_upload_threshold

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1018,9 +1018,12 @@ class CloudFiles:
             downloaded = compression.transcode(downloaded, reencode, in_place=True)
           def renameiter():
             for item in downloaded:
-              if "dest_path" in item:
-                item["path"] = item["dest_path"]
-                del item["dest_path"]
+              if (
+                item["tags"] is not None
+                and "dest_path" in item["tags"]
+              ):
+                item["path"] = item["tags"]["dest_path"]
+                del item["tags"]["dest_path"]
               yield item
           self.puts(renameiter(), raw=True, progress=False, compress=reencode)
           pbar.update(len(block_paths))

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -919,8 +919,8 @@ class CloudFiles:
       an iterable, transfer only these files.
 
       A path is an iterable that contains str, dict, tuple, or list
-      elements. If dict, by adding the "dest_path" key, you can 
-      rename objects being copied. With tuple or list, the first
+      elements. If dict, by adding the "dest_path" key to "tags", you 
+      can rename objects being copied. With tuple or list, the first
       element of the pair is the source key, the second element
       is the destination key.
 
@@ -963,8 +963,8 @@ class CloudFiles:
       an iterable, transfer only these files.
 
       A path is an iterable that contains str, dict, tuple, or list
-      elements. If dict, by adding the "dest_path" key, you can 
-      rename objects being copied. With tuple or list, the first
+      elements. If dict, by adding the "dest_path" key to "tags", you 
+      can rename objects being copied. With tuple or list, the first
       element of the pair is the source key, the second element
       is the destination key.
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1039,9 +1039,6 @@ class CloudFiles:
       if isinstance(path, dict):
         src = os.path.join(srcdir, path["path"])
         dest = os.path.join(destdir, path["dest_path"])
-      elif isinstance(path, (tuple,list)):
-        src = os.path.join(srcdir, path[0]) 
-        dest = os.path.join(destdir, path[1])
       else:
         src = os.path.join(srcdir, path)
         dest = os.path.join(destdir, path)
@@ -1068,8 +1065,6 @@ class CloudFiles:
         if isinstance(path, dict):
           src_path = path["path"]
           dest_path = path.get("dest_path", path["path"])
-        elif isinstance(path, (tuple,list)):
-          src_path, dest_path = path[0], path[1]
         else:
           src_path = path
           dest_path = posixpath.sep.join(path.split(os.path.sep))
@@ -1097,8 +1092,6 @@ class CloudFiles:
         if isinstance(key, dict):
           dest_key = key.get("dest_path", key["path"])
           src_key = key["path"]
-        elif isinstance(key, (tuple,list)):
-          src_key, dest_key = key[0], key[1]
         else:
           src_key = key
           dest_key = key

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1025,6 +1025,9 @@ class CloudFiles:
         src = os.path.join(srcdir, path)
         dest = os.path.join(destdir, path)
       mkdir(os.path.dirname(dest))
+      src, encoding = FileInterface.get_encoded_file_path(src)
+      _, ext = os.path.splitext(src)
+      dest += ext
       shutil.copyfile(src, dest) # avoids user space
       pbar.update(1)
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1016,7 +1016,7 @@ class CloudFiles:
           for path in block_paths:
             if isinstance(path, dict):
               if "dest_path" in path:
-                path["tags"] = { "dest_path": dest_path }
+                path["tags"] = { "dest_path": path["dest_path"] }
           downloaded = cf_src.get(block_paths, raw=True, progress=False)
           if reencode is not None:
             downloaded = compression.transcode(downloaded, reencode, in_place=True)

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1072,7 +1072,7 @@ class CloudFiles:
   ):
     """For performing internal transfers in gs or s3."""
     def thunk_copy(key):
-      with self._get_connection() as conn:
+      with cf_src._get_connection() as conn:
         if isinstance(key, dict):
           dest_key = key.get("dest_path", key["path"])
           src_key = key["path"]

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -903,9 +903,29 @@ class CloudFiles:
     to the destination CloudFiles in batches sized 
     in the number of files.
 
-    cf_dest: another CloudFiles instance or a cloudpath
+    Where possible (file->file, file->cloud, gs->gs, and s3->s3),
+    this function will attempt to improve performance by using
+    specialized functions to perform the transfer.
+
+      - file->file: Uses OS functions for fast file copying (Python 3.8+)
+      - file->cloud: Uses file handles to allow low-memory
+        multipart upload
+      - gs->gs: Uses GCS copy API to minimize data movement
+      - s3->s3: Uses boto s3 copy API to minimize data movement
+
+    cf_src: another CloudFiles instance or cloudpath 
     paths: if None transfer all files from src, else if
       an iterable, transfer only these files.
+
+      A path is an iterable that contains str, dict, tuple, or list
+      elements. If dict, by adding the "dest_path" key, you can 
+      rename objects being copied. With tuple or list, the first
+      element of the pair is the source key, the second element
+      is the destination key.
+
+      A CloudFiles object may be supplied as a paths object
+      which will trigger the listing operation.
+
     block_size: number of files to transfer per a batch
     reencode: if not None, reencode the compression type
       as '' (None), 'gzip', 'br', 'zstd'

--- a/cloudfiles/connectionpools.py
+++ b/cloudfiles/connectionpools.py
@@ -14,7 +14,7 @@ import tenacity
 from .secrets import google_credentials, aws_credentials
 from .exceptions import UnsupportedProtocolError
 
-MEMORY_DATA:Dict[str,bytes] = {}
+MEMORY_DATA:Dict[str,Dict[str,bytes]] = {}
 
 retry = tenacity.retry(
   reraise=True, 
@@ -163,5 +163,7 @@ class MemoryPool(ConnectionPool):
     super(MemoryPool, self).__init__()
 
   def _create_connection(self, secrets=None, endpoint=None):
-    return self.data
+    if self.bucket not in self.data:
+      self.data[self.bucket] = {}
+    return self.data[self.bucket]
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -793,7 +793,7 @@ class S3Interface(StorageInterface):
     dest_bucket = self._get_bucket(dest_bucket_name)
     copy_source = {
       'Bucket': self._path.bucket,
-      'Key': src_path,
+      'Key': key,
     }
     dest_bucket.copy(CopySource=copy_source, Bucket=dest_bucket_name, Key=dest_key)
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -85,6 +85,28 @@ class FileInterface(StorageInterface):
   def get_path_to_file(self, file_path):
     return os.path.join(self._path.path, file_path)
 
+  @classmethod
+  def get_encoded_file_path(kls, path):
+    if os.path.exists(path + '.gz'):
+      encoding = "gzip"
+      path += '.gz'
+    elif os.path.exists(path + '.br'):
+      encoding = "br"
+      path += ".br"
+    elif os.path.exists(path + '.zstd'):
+      encoding = "zstd"
+      path += ".zstd"
+    elif os.path.exists(path + '.xz'):
+      encoding = "xz" # aka lzma
+      path += ".xz"
+    elif os.path.exists(path + '.bz2'):
+      encoding = "bzip2"
+      path += ".bz2"
+    else:
+      encoding = None
+
+    return path, encoding
+
   def put_file(
     self, file_path, content, 
     content_type, compress, 
@@ -130,23 +152,7 @@ class FileInterface(StorageInterface):
   def head(self, file_path):
     path = self.get_path_to_file(file_path)
 
-    if os.path.exists(path + '.gz'):
-      encoding = "gzip"
-      path += '.gz'
-    elif os.path.exists(path + '.br'):
-      encoding = "br"
-      path += ".br"
-    elif os.path.exists(path + '.zstd'):
-      encoding = "zstd"
-      path += ".zstd"
-    elif os.path.exists(path + '.xz'):
-      encoding = "xz" # aka lzma
-      path += ".xz"
-    elif os.path.exists(path + '.bz2'):
-      encoding = "bzip2"
-      path += ".bz2"
-    else:
-      encoding = None   
+    path, encoding = self.get_encoded_file_path(path)
 
     try:
       statinfo = os.stat(path)
@@ -171,23 +177,7 @@ class FileInterface(StorageInterface):
   def get_file(self, file_path, start=None, end=None):
     path = self.get_path_to_file(file_path)
 
-    if os.path.exists(path + '.gz'):
-      encoding = "gzip"
-      path += '.gz'
-    elif os.path.exists(path + '.br'):
-      encoding = "br"
-      path += ".br"
-    elif os.path.exists(path + '.zstd'):
-      encoding = "zstd"
-      path += ".zstd"
-    elif os.path.exists(path + '.xz'):
-      encoding = "xz" # aka lzma
-      path += ".xz"
-    elif os.path.exists(path + '.bz2'):
-      encoding = "bzip2"
-      path += ".bz2"
-    else:
-      encoding = None
+    path, encoding = self.get_encoded_file_path(path)
 
     try:
       with open(path, 'rb') as f:
@@ -226,16 +216,12 @@ class FileInterface(StorageInterface):
 
   def delete_file(self, file_path):
     path = self.get_path_to_file(file_path)
-    if os.path.exists(path):
+    path, encoding = self.get_encoded_file_path(path)
+
+    try:
       os.remove(path)
-    elif os.path.exists(path + '.gz'):
-      os.remove(path + '.gz')
-    elif os.path.exists(path + ".br"):
-      os.remove(path + ".br")
-    elif os.path.exists(path + '.xz'):
-      os.remove(path + ".xz")
-    elif os.path.exists(path + '.bz2'):
-      os.remove(path + ".bz2")
+    except FileNotFoundError:
+      pass
 
   def delete_files(self, file_paths):
     for path in file_paths:

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -87,7 +87,9 @@ class FileInterface(StorageInterface):
 
   @classmethod
   def get_encoded_file_path(kls, path):
-    if os.path.exists(path + '.gz'):
+    if os.path.exists(path):
+      encoding = None
+    elif os.path.exists(path + '.gz'):
       encoding = "gzip"
       path += '.gz'
     elif os.path.exists(path + '.br'):

--- a/cloudfiles/paths.py
+++ b/cloudfiles/paths.py
@@ -329,7 +329,7 @@ def extract(cloudpath:str, windows=None) -> ExtractedPath:
     cloudpath = toabs(cloudpath)
 
   bucket = None
-  if protocol in ('gs', 's3', 'matrix'):
+  if protocol in ('gs', 's3', 'matrix', 'mem'):
     match = re.match(bucket_re, cloudpath)
     if not match:
       raise error

--- a/cloudfiles/scheduler.py
+++ b/cloudfiles/scheduler.py
@@ -113,7 +113,7 @@ def schedule_single_threaded_jobs(
 
 def schedule_jobs(
     fns, concurrency=DEFAULT_THREADS, 
-    progress=None, total=None, green=False,
+    progress=None, total=None, green=None,
     count_return=False
   ):
   """
@@ -124,7 +124,7 @@ def schedule_jobs(
   concurrency: number of threads
   progress: Falsey (no progress), String: Progress + description
   total: If fns is a generator, this is the number of items to be generated.
-  green: If True, use green threads.
+  green: If True, use green threads. If None, check if monkey patched.
 
   Return: list of results
   """
@@ -137,7 +137,7 @@ def schedule_jobs(
   ):
     return schedule_single_threaded_jobs(fns, progress, total, count_return)
     
-  if green:
+  if green == True or (green is None and gevent.monkey.saved):
     return schedule_green_jobs(fns, concurrency, progress, total, count_return)
 
   return schedule_threaded_jobs(fns, concurrency, progress, total, count_return)

--- a/cloudfiles/scheduler.py
+++ b/cloudfiles/scheduler.py
@@ -130,7 +130,11 @@ def schedule_jobs(
   """
   if concurrency < 0:
     raise ValueError("concurrency value cannot be negative: {}".format(concurrency))
-  elif concurrency == 0:
+  elif (
+    concurrency == 0 
+    or (isinstance(total, int) and total <= 1) 
+    or (hasattr(fns, "__len__") and len(fns) <= 1)
+  ):
     return schedule_single_threaded_jobs(fns, progress, total, count_return)
     
   if green:

--- a/cloudfiles/scheduler.py
+++ b/cloudfiles/scheduler.py
@@ -1,5 +1,6 @@
 import sys
 
+import gevent.monkey
 from tqdm import tqdm
 
 from .threaded_queue import ThreadedQueue, DEFAULT_THREADS

--- a/cloudfiles_cli/__init__.py
+++ b/cloudfiles_cli/__init__.py
@@ -1,4 +1,1 @@
-import gevent.monkey
-gevent.monkey.patch_all(thread=False)
-
 from .cloudfiles_cli import *

--- a/cloudfiles_cli/__init__.py
+++ b/cloudfiles_cli/__init__.py
@@ -1,4 +1,4 @@
 import gevent.monkey
-gevent.monkey.patch_all(thread=False)
+gevent.monkey.patch_all(thread=True)
 
 from .cloudfiles_cli import *

--- a/cloudfiles_cli/__init__.py
+++ b/cloudfiles_cli/__init__.py
@@ -1,4 +1,4 @@
 import gevent.monkey
-gevent.monkey.patch_all(thread=True)
+gevent.monkey.patch_all(thread=False)
 
 from .cloudfiles_cli import *

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -291,7 +291,7 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
 
     cfsrc.transfer_to(cfdest, paths=[{
       "path": xferpaths,
-      "dest_path": new_path,
+      "tags": { "dest_path": new_path },
     }], reencode=compression)
 
 def _cp(src, dst, compression, progress, block_size, paths):

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -291,7 +291,7 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
 
     cfsrc.transfer_to(cfdest, paths=[{
       "path": xferpaths,
-      "tags": { "dest_path": new_path },
+      "dest_path": new_path,
     }], reencode=compression)
 
 def _cp(src, dst, compression, progress, block_size, paths):

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -284,25 +284,15 @@ def _cp_single(ctx, source, destination, recursive, compression, progress, block
 
     cfdest = CloudFiles(destpath, green=True, progress=progress)
 
-    # high performance local copy
-    if (
-      cfsrc.protocol == "file" 
-      and cfdest.protocol == "file" 
-      and compression is None
-    ):
-      if isdestdir:
-        ndest = os.path.join(ndest, os.path.basename(nsrc))
-      shutil.copyfile(nsrc.replace("file://", ""), ndest.replace("file://", ""))
-      return
-    
-    downloaded = cfsrc.get([ xferpaths ], raw=True)
-    if compression is not None:
-      downloaded = next(transcode(downloaded, compression, in_place=True))
-    
     if isdestdir:
-      cfdest.put(os.path.basename(nsrc), downloaded["content"], raw=True, compress=compression)
+      new_path = os.path.basename(nsrc)
     else:
-      cfdest.put(os.path.basename(ndest), downloaded["content"], raw=True, compress=compression)
+      new_path = os.path.basename(ndest)
+
+    cfsrc.transfer_to(cfdest, paths=[{
+      "path": xferpaths,
+      "dest_path": new_path,
+    }], reencode=compression)
 
 def _cp(src, dst, compression, progress, block_size, paths):
   cfsrc = CloudFiles(src, green=True, progress=progress)


### PR DESCRIPTION
- More comprehensive testing of transfer_to/transfer_from
- Fixes for `mem://` protocol (parsing, buckets)
- File-to-file transfers handle compression
- Low memory transfer to gs, s3 by using file handles from local disk
- gs->gs and s3->s3 copies no longer require download/upload from client
- Support for renaming files during transfer
- Use the main thread for single element jobs
- Removes monkey patch from CLI as this causes problems with boto's advanced functions which use threads under the hood
- CloudFiles automatically decides whether to use threads or green threads depending on the monkey patch state (you can still force it to use one or the other)