### PR TITLE
fix: ensure http secrets is compatible with graphene tokens

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Manuel Castro <macastro@princeton.edu>
 Nico Kemnitz <nkemnitz@princeton.edu>
+V24 <55334829+umarfarouk98@users.noreply.github.com>
 William Silversmith <william.silversmith@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,42 @@
 CHANGES
 =======
 
+4.15.1
+------
+
+* fix: missing BytesIO import
+
+4.15.0
+------
+
+* perf: better memory usage for file to gs/s3 transfer (#87)
+* fix: add file handle support for MemoryInterface
+
+4.14.0
+------
+
+* docs: describe GCS composite and S3 multi-part uploads
+* docs: update highlights, show cloudfiles
+* install: update supported python versions
+* install: adjust python requires to be 3.7+
+* feat: make s3 multi-part threshold configurable
+* feat: add support for CLOUD\_VOLUME\_DIR and CLOUD\_FILES\_DIR env vars (#83)
+* feat: multi-part s3 upload support (#85)
+* feat: support for GCS composite uploads (#86)
+* feat: add and remove persistent aliases (#84)
+* feat: http basic auth support (#82)
+
+4.13.0
+------
+
+* feat: add clear\_memory function
+
+4.12.1
+------
+
+* feat: add .protocol to CloudFile object
+* chore: update ChangeLog
+
 4.12.0
 ------
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -172,10 +172,20 @@ def test_get_generator(num_threads, green):
   cf.delete(( str(i) for i in range(100) ))
   assert list(cf.list()) == []
 
-def test_http_read():
+@pytest.mark.parametrize("secrets", [
+  None,
+  { "token": "hello world" },
+  { "user": "hello", "password": "world" },
+])
+def test_http_read(secrets):
   from cloudfiles import CloudFiles, exceptions
-  cf = CloudFiles("https://storage.googleapis.com/seunglab-test/test_v0/black/")
-  info = cf.get_json('info')
+  import requests
+  cf = CloudFiles("https://storage.googleapis.com/seunglab-test/test_v0/black/", secrets=secrets)
+  
+  try:
+    info = cf.get_json('info')
+  except requests.exceptions.HTTPError:
+    return
 
   assert info == {
     "data_type": "uint8",

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -65,7 +65,6 @@ retry = tenacity.retry(
   reraise=True, 
   stop=tenacity.stop_after_attempt(7), 
   wait=tenacity.wait_random_exponential(0.5, 60.0),
-  retry=tenacity.retry_if_not_exception_type(requests.exceptions.HTTPError),
 )
 
 class StorageInterface(object):

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -65,6 +65,7 @@ retry = tenacity.retry(
   reraise=True, 
   stop=tenacity.stop_after_attempt(7), 
   wait=tenacity.wait_random_exponential(0.5, 60.0),
+  retry=tenacity.retry_if_not_exception_type(requests.exceptions.HTTPError),
 )
 
 class StorageInterface(object):
@@ -612,7 +613,7 @@ class HttpInterface(StorageInterface):
       secrets = http_credentials()
 
     self.session = requests.Session()
-    if secrets:
+    if secrets and 'user' in secrets and 'password' in secrets:
       self.session.auth = (secrets['user'], secrets['password'])
 
   def get_path_to_file(self, file_path):


### PR DESCRIPTION
Allows token type secrets to be fed in. 

Also makes retry abort quickly for requests.exceptions.HTTPError