### PR TITLE
Use fasteners to lock local files

### DIFF
--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -248,6 +248,7 @@ class CloudFiles:
     green:Optional[bool] = None, secrets:SecretsType = None, num_threads:int = 20,
     use_https:bool = False, endpoint:Optional[str] = None, 
     parallel:ParallelType = 1, request_payer:Optional[str] = None,
+    locking:Optional[bool] = None,
     composite_upload_threshold:int = int(1e8)
   ):
     if use_https:
@@ -260,6 +261,7 @@ class CloudFiles:
     self.green = green
     self.parallel = int(parallel)
     self.request_payer = request_payer
+    self.locking = locking
     self.composite_upload_threshold = composite_upload_threshold
 
     self._path = paths.extract(cloudpath)
@@ -281,6 +283,7 @@ class CloudFiles:
       self._path, 
       secrets=self.secrets,
       request_payer=self.request_payer,
+      locking=self.locking,
       composite_upload_threshold=self.composite_upload_threshold,
     )
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -249,6 +249,7 @@ class CloudFiles:
     use_https:bool = False, endpoint:Optional[str] = None, 
     parallel:ParallelType = 1, request_payer:Optional[str] = None,
     locking:Optional[bool] = None,
+    lock_dir:Optional[str] = None,
     composite_upload_threshold:int = int(1e8)
   ):
     if use_https:
@@ -262,6 +263,7 @@ class CloudFiles:
     self.parallel = int(parallel)
     self.request_payer = request_payer
     self.locking = locking
+    self.lock_dir = lock_dir
     self.composite_upload_threshold = composite_upload_threshold
 
     self._path = paths.extract(cloudpath)
@@ -284,6 +286,7 @@ class CloudFiles:
       secrets=self.secrets,
       request_payer=self.request_payer,
       locking=self.locking,
+      lock_dir=self.lock_dir,
       composite_upload_threshold=self.composite_upload_threshold,
     )
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -102,13 +102,15 @@ def read_file(path, encoding, start, end):
   return (data, encoding, None, None)
 
 class FileInterface(StorageInterface):
-  def __init__(self, path, secrets=None, request_payer=None, locking=None, **kwargs):
+  def __init__(self, path, secrets=None, request_payer=None, locking=None, lock_dir=None, **kwargs):
     super(StorageInterface, self).__init__()
     self._path = path
     if request_payer is not None:
       raise ValueError("Specifying a request payer for the FileInterface is not supported. request_payer must be None, got '{}'.".format(request_payer))
 
-    lock_dir = CLOUD_FILES_LOCK_DIR
+    if lock_dir is None:
+      lock_dir = CLOUD_FILES_LOCK_DIR
+
     if locking is True and lock_dir is None:
       lock_dir = os.path.join(CLOUD_FILES_DIR, "locks")
 

--- a/cloudfiles/secrets.py
+++ b/cloudfiles/secrets.py
@@ -17,6 +17,8 @@ CF_HOME = os.path.join(HOME, '.cloudfiles')
 CLOUD_FILES_DIR = os.environ.get("CLOUD_FILES_DIR", CF_HOME)
 CLOUD_FILES_SECRETS_DIR = os.path.join(CLOUD_FILES_DIR, 'secrets')
 
+CLOUD_FILES_LOCK_DIR = os.environ.get("CLOUD_FILES_LOCK_DIR", None)
+
 CredentialType = Dict[str,Union[str,int]]
 CredentialCacheType = Dict[str,CredentialType]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tqdm
 urllib3>=1.26.3
 zstandard
 rsa>=4.7.2
+fasteners


### PR DESCRIPTION
This mainly helps when using multiple cloud-volume instance with local cache, without locking the cache maybe read when incomplete. Use fastener to put a shared lock when reading files and an exclusive lock when writing files.
The patch creates a `xxx.lock` file when cloud-files try to access file `xxx`, in the same folder. If it does not have write permit, fallback to the no lock path, though I am not sure if it make sense to still try put files in that case. I did not try cleanup the files, since it is tricky to find out when all the locks are resolved. An alternative approach is to create lock files somewhere else, maybe some folder under `CLOUD_FILES_DIR`
Only tested the patch under linux.