### PR TITLE
Add support for AWS_SESSION_TOKEN

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -44,6 +44,16 @@ def s3(aws_credentials):
     conn.create_bucket(Bucket="cloudfiles_dest")
     yield conn
 
+def test_aws_credentials(aws_credentials):
+  from cloudfiles import secrets
+  expected = {
+    'AWS_ACCESS_KEY_ID': 'testing',
+    'AWS_SECRET_ACCESS_KEY': 'testing',
+    'AWS_SESSION_TOKEN': 'testing',
+    'AWS_DEFAULT_REGION': 'us-east-1',
+  }
+  assert secrets.aws_credentials() == expected
+
 @pytest.mark.parametrize("green", (False, True))
 @pytest.mark.parametrize("num_threads", (0, 5, 20))
 @pytest.mark.parametrize("protocol", ('mem', 'file', 's3'))#'gs'))

--- a/cloudfiles/connectionpools.py
+++ b/cloudfiles/connectionpools.py
@@ -117,6 +117,7 @@ class S3ConnectionPool(ConnectionPool):
       's3',
       aws_access_key_id=secrets.get('AWS_ACCESS_KEY_ID', None),
       aws_secret_access_key=secrets.get('AWS_SECRET_ACCESS_KEY', None),
+      aws_session_token=secrets.get('AWS_SESSION_TOKEN', None),
       region_name=secrets.get('AWS_DEFAULT_REGION', 'us-east-1'),
       **additional_args
     )

--- a/cloudfiles/secrets.py
+++ b/cloudfiles/secrets.py
@@ -128,6 +128,7 @@ def aws_credentials(bucket = '', service = 'aws'):
       aws_credentials = {
         'AWS_ACCESS_KEY_ID': os.environ['AWS_ACCESS_KEY_ID'],
         'AWS_SECRET_ACCESS_KEY': os.environ['AWS_SECRET_ACCESS_KEY'],
+        'AWS_SESSION_TOKEN': os.environ['AWS_SESSION_TOKEN'],
       }
     if 'AWS_DEFAULT_REGION' in os.environ:
       aws_credentials['AWS_DEFAULT_REGION'] = os.environ['AWS_DEFAULT_REGION']


### PR DESCRIPTION
This PR adds support for `AWS_SESSION_TOKEN` so that users can use an AWS account that supports this when using CloudFiles. Previously, requests would all return `Forbidden` because the session token was not actually being used during boto3 client creation. The PR adds support for `AWS_SESSION_TOKEN` to be used in an environment variable as well as through `aws-secret.json`. Fixes #101 .