### PR TITLE
fix: prevent aws-chunked from populating in Content-Encoding

### DIFF
--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -22,7 +22,7 @@ import fasteners
 from .compression import COMPRESSION_TYPES
 from .connectionpools import S3ConnectionPool, GCloudBucketPool, MemoryPool, MEMORY_DATA
 from .exceptions import MD5IntegrityError, CompressionError, AuthorizationError
-from .lib import mkdir, sip, md5, validate_s3_multipart_etag
+from .lib import mkdir, sip, md5, encode_crc32c_b64, validate_s3_multipart_etag
 from .secrets import (
   http_credentials,
   cave_credentials,
@@ -1166,7 +1166,7 @@ class S3Interface(StorageInterface):
       attrs['Bucket'] = self._path.bucket
       attrs['Body'] = content
       attrs['Key'] = key
-      attrs['ContentMD5'] = md5(content)
+      attrs["ChecksumCRC32C"] = str(encode_crc32c_b64(content))
       self._conn.put_object(**attrs)
 
   @retry

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1171,7 +1171,7 @@ class S3Interface(StorageInterface):
         Key=key,
         CopySource={'Bucket': self._path.bucket, 'Key': key},
         MetadataDirective="REPLACE",
-        ContentEncoding=attrs.get("ContentEncoding", ""),  # Set the new Content-Encoding
+        **attrs
       )
     else:
       attrs['Bucket'] = self._path.bucket

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1138,7 +1138,7 @@ class S3Interface(StorageInterface):
     elif compress in ("xz", "lzma"):
       attrs['ContentEncoding'] = 'xz'
     elif compress in ("bzip2", "bz2"):
-      attrs['ContentEncoding'] = 'bz2'
+      attrs['ContentEncoding'] = 'bzip2'
     elif compress:
       raise ValueError("Compression type {} not supported.".format(compress))
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1262,8 +1262,9 @@ class S3Interface(StorageInterface):
 
     mkdir(os.path.dirname(dest))
 
+    encoding = resp.get("Content-Encoding", "") or ""
     encoding = ",".join([ 
-      enc for enc in resp.get("Content-Encoding", "").split(",")
+      enc for enc in encoding.split(",")
       if enc != "aws-chunked"
     ])
     ext = FileInterface.get_extension(encoding)

--- a/cloudfiles/lib.py
+++ b/cloudfiles/lib.py
@@ -153,6 +153,11 @@ def decode_crc32c_b64(b64digest):
   # !I means network order (big endian) and unsigned int
   return struct.unpack("!I", base64.b64decode(b64digest))[0]
 
+def encode_crc32c_b64(binary):
+  val = crc32c(binary)
+  val = val.to_bytes(4, 'big')
+  return base64.b64encode(val)
+
 def crc32c(binary):
   """
   Computes the crc32c of a binary string 


### PR DESCRIPTION
AWS recently changed their file upload validation procedure and seem to be ignoring ContentMD5 and instead are applying their own algorithm. This causes ",aws-chunked" to get appended to the Content-Encoding field which causes havoc.

We circumvent this behavior in this PR by calculating the crc32c and specifying it as the chosen algorithm up front.

This is probably a net benefit, since crc32c can be computed at 100 GB/sec these days (though this implementation is probably only ~1 GB/sec).
