### PR TITLE
fix: support |format: style of cloudpaths

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -538,6 +538,13 @@ def test_path_extraction():
         'dataset/layer', None, None
       ))
 
+  assert (
+    paths.extract('gs://bucket/dataset/layer|zarr2:') 
+      == ExtractedPath(
+        'zarr2', 'gs', 'bucket', 
+        'dataset/layer', None, None
+      ))
+
   okgoogle('gs://bucket/dataset/layer/')
   # shoulderror('gs://bucket/dataset/layer/info')
 


### PR DESCRIPTION
CloudFiles path parsing now supports e.g. gs://bucket/path/|zarr2: in addition to zarr2://gs://bucket/path/