### PR TITLE
fix: try different multi-processing method

### DIFF
--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -16,8 +16,7 @@ import sys
 # High Sierra and above when we are using
 # a thread before forking. Instead, don't fork,
 # spawn entirely new processes.
-import multiprocess.context as ctx
-ctx._force_start_method('spawn')
+mp.set_start_method("spawn", force=True)
 
 import click
 import pathos.pools


### PR DESCRIPTION
This changes the instruction to multiprocessing to use "spawn" seemingly correctly. So far in my testing, the bug where high process counts causes freezing disappears.

Thanks ChatGPT for the correct invocation.