### PR TITLE
fix(cave): expanded credentials methods

### DIFF
--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1497,8 +1497,18 @@ class CaveInterface(HttpInterface):
   is, don't worry about it.
   see: https://github.com/CAVEconnectome
   """
-  def default_headers(self):
-    cred = cave_credentials()
+  def __init__(self, *args, **kwargs):
+    super(*args, *kwargs)
+
+    secrets = kwargs.get('secrets', {})
+    self._token = secrets.get('token', None)
+    if self._token is None:
+      self._token = cave_credentials()['token']    
+
+  def default_headers(self) -> dict:
+    if self._token is None:
+      return {}
+    
     return {
-      "Authorization": f"Bearer {cred['token']}",
+      "Authorization": f"Bearer {self._token}",
     }

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1497,13 +1497,20 @@ class CaveInterface(HttpInterface):
   is, don't worry about it.
   see: https://github.com/CAVEconnectome
   """
-  def __init__(self, *args, **kwargs):
-    super(*args, *kwargs)
+  def __init__(self, path, secrets=None, **kwargs):
+    super().__init__(path, secrets=secrets, **kwargs)
 
-    secrets = kwargs.get('secrets', {})
+    secrets = kwargs.get('secrets', None)
+    if secrets is None:
+      secrets = {}
+
     self._token = secrets.get('token', None)
     if self._token is None:
-      self._token = cave_credentials()['token']    
+      server = self._path.host.replace("https://", "", 1)
+      server = server.replace("http://", "", 1)
+      self._token = cave_credentials(server)
+      if self._token is not None:
+        self._token = self._token.get('token', None)
 
   def default_headers(self) -> dict:
     if self._token is None:

--- a/cloudfiles/secrets.py
+++ b/cloudfiles/secrets.py
@@ -137,23 +137,27 @@ def aws_credentials(bucket = '', service = 'aws', skip_files=False):
   AWS_CREDENTIALS_CACHE[service][bucket] = aws_credentials
   return aws_credentials
 
-CAVE_CREDENTIALS = None
-def cave_credentials():
+CAVE_CREDENTIALS:CredentialCacheType = {}
+def cave_credentials(server = ''):
   global CAVE_CREDENTIALS
-  default_file_path = 'cave-secret.json'
-  path = secretpath(default_file_path)
 
-  if CAVE_CREDENTIALS:
-    return CAVE_CREDENTIALS
+  paths = [
+    secretpath('cave-secret.json')
+  ]
 
-  if os.path.exists(path):
-    with open(path, 'rt') as f:
-      CAVE_CREDENTIALS = json.loads(f.read())
-  else:
-    CAVE_CREDENTIALS = None
+  if server:
+    paths = [ secretpath(f'{server}-cave-secret.json') ] + paths
 
-  return CAVE_CREDENTIALS
+  if server in CAVE_CREDENTIALS:
+    return CAVE_CREDENTIALS.get(server, None)
 
+  for path in paths:
+    if os.path.exists(path):
+      with open(path, 'rt') as f:
+        CAVE_CREDENTIALS[server] = json.loads(f.read())
+      break
+
+  return CAVE_CREDENTIALS.get(server, None)
 
 HTTP_CREDENTIALS = None
 def http_credentials():


### PR DESCRIPTION
Accept `secrets={'token': ... }` as well as `SERVER-cave-secret.json` files.