### PR TITLE
perf: handle small numbers of remote file more efficiently

### DIFF
--- a/cloudfiles/scheduler.py
+++ b/cloudfiles/scheduler.py
@@ -137,7 +137,12 @@ def schedule_jobs(
     or (hasattr(fns, "__len__") and len(fns) <= 1)
   ):
     return schedule_single_threaded_jobs(fns, progress, total, count_return)
-    
+  
+  if isinstance(total, int):
+    concurrency = min(concurrency, max(total, 1))
+  elif hasattr(fns, "__len__"):
+    concurrency = min(concurrency, max(len(fns), 1))
+
   if green == True or (green is None and gevent.monkey.saved):
     return schedule_green_jobs(fns, concurrency, progress, total, count_return)
 


### PR DESCRIPTION
It was reported that launching 20 green threads caused unnecessary delays waiting for the threads to finish when small numbers of files were requested. This change limits the number of threads to the number of files if they are fewer than the specified number of threads.