### PR TITLE
feat: performance monitoring

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -e ".[test]"; fi
+        if [ -f requirements.txt ]; then pip install -e ".[test,monitoring]"; fi
     - name: Test with pytest
       run: |
         python -m pytest -v -x automated_test.py

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ CloudFiles was developed to access files from object storage without ever touchi
 ```bash
 pip install cloud-files
 pip install cloud-files[test] # to enable testing with pytest
+pip install cloud-files[monitoring] # enable plotting network performance
 ```
 
 If you run into trouble installing dependenies, make sure you're using at least Python3.6 and you have updated pip. On Linux, some dependencies require manylinux2010 or manylinux2014 binaries which earlier versions of pip do not search for. MacOS, Linux, and Windows are supported platforms.

--- a/README.md
+++ b/README.md
@@ -446,9 +446,9 @@ cloudfiles cp -c none s3://bkt/file.txt gs://bkt2/
 # save chart of file flight times
 cloudfiles cp --flight-time s3://bkt/file.txt gs://bkt2/
 # save a chart of estimated bandwidth usage from these files alone
-cloudfiles cp --io-chart s3://bkt/file.txt gs://bkt2/
+cloudfiles cp --io-rate s3://bkt/file.txt gs://bkt2/
 # save a chart of measured bandwidth usage for the machine
-cloudfiles cp --machine-io-chart s3://bkt/file.txt gs://bkt2/
+cloudfiles cp --machine-io-rate s3://bkt/file.txt gs://bkt2/
 # move or rename files
 cloudfiles mv s3://bkt/file.txt gs://bkt2/
 # create an empty file if not existing
@@ -528,7 +528,7 @@ tm.plot_histogram() # transfer rate chart
 ```
 
 
-A second object, `IOSampler`, can sample the OS network counters using a background thread and provides a global view of the machine's network performance during the life of the transfer. It is enabled on the CLI for the `cp` command when the `--machine-io-chart` flag is enabled, but must be manually started programatically. This is to avoid accidentally starting unnecessary sampling threads. The samples are accumulated into a circular buffer, so make sure to set the buffer length long enough for your points of interest to be captured.
+A second object, `IOSampler`, can sample the OS network counters using a background thread and provides a global view of the machine's network performance during the life of the transfer. It is enabled on the CLI for the `cp` command when the `--machine-io-rate` flag is enabled, but must be manually started programatically. This is to avoid accidentally starting unnecessary sampling threads. The samples are accumulated into a circular buffer, so make sure to set the buffer length long enough for your points of interest to be captured.
 
 ```python
 from cloudfiles.monitoring import IOSampler

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -21,7 +21,6 @@ import shutil
 import types
 import time
 
-import intervaltree
 import orjson
 import pathos.pools
 from tqdm import tqdm

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -35,7 +35,7 @@ from .lib import (
   duplicates, first, sip, touch,
   md5, crc32c, decode_crc32c_b64
 )
-from .monitoring import TransmissionMonitor
+from .monitoring import TransmissionMonitor, IOEnum
 from .paths import ALIASES, find_common_buckets
 from .secrets import CLOUD_FILES_DIR, CLOUD_FILES_LOCK_DIR
 from .threaded_queue import ThreadedQueue, DEFAULT_THREADS
@@ -448,7 +448,7 @@ class CloudFiles:
     # return_dict prevents the user from having a chance
     # to inspect errors, so we must raise here.
     raise_errors = raise_errors or return_dict or (not multiple_return)
-    tm = TransmissionMonitor()
+    tm = TransmissionMonitor(IOEnum.RX)
 
     def check_md5(path, content, server_hash):
       if server_hash is None:
@@ -661,7 +661,7 @@ class CloudFiles:
     """
     files = toiter(files)
     progress = nvl(progress, self.progress)
-    tm = TransmissionMonitor()
+    tm = TransmissionMonitor(IOEnum.TX)
 
     def todict(file):
       if isinstance(file, tuple):
@@ -1375,7 +1375,7 @@ class CloudFiles:
     shutil.copyfile, starting in Python 3.8, uses
     special OS kernel functions to accelerate file copies
     """
-    tm = TransmissionMonitor()
+    tm = TransmissionMonitor(IOEnum.TX)
     srcdir = cf_src.cloudpath.replace("file://", "")
     destdir = mkdir(cf_dest.cloudpath.replace("file://", ""))
     for path in paths:
@@ -1421,7 +1421,7 @@ class CloudFiles:
     allow_missing, resumable,
   ) -> TransmissionMonitor:
 
-    tm = TransmissionMonitor()
+    tm = TransmissionMonitor(IOEnum.RX)
 
     def thunk_save(key):
       nonlocal tm
@@ -1524,7 +1524,7 @@ class CloudFiles:
     of the cloud, this is much slower and more expensive
     than necessary.
     """
-    tm = TransmissionMonitor()
+    tm = TransmissionMonitor(IOEnum.TX)
 
     def thunk_copy(key):
       nonlocal tm

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -484,6 +484,8 @@ class CloudFiles:
       server_hash = None
       server_hash_type = None
       try:
+        tm.start_io(1)
+
         with self._get_connection() as conn:
           content, encoding, server_hash, server_hash_type = conn.get_file(
             path, start=start, end=end, part_size=part_size
@@ -691,6 +693,8 @@ class CloudFiles:
         num_bytes_tx = len(content)
       elif isinstance(content, io.IOBase):
         num_bytes_tx = os.fstat(content.fileno()).st_size
+
+      tm.start_io(num_bytes_tx)
 
       if (
         self.protocol == "gs" 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -497,7 +497,7 @@ class CloudFiles:
         raise error
 
       finish_time = time.time()
-      tm.add(start_time, finish_time, num_bytes_rx)
+      tm.end_io(start_time, finish_time, num_bytes_rx)
 
       return { 
         'path': path, 
@@ -696,7 +696,7 @@ class CloudFiles:
 
       finish_time = time.time()
       if self.max_bps_up >= 0:
-        tm.add(start_time, finish_time, num_bytes_tx)
+        tm.end_io(start_time, finish_time, num_bytes_tx)
 
     if not isinstance(files, (types.GeneratorType, zip)):
       dupes = duplicates([ todict(file)['path'] for file in files ])

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -638,6 +638,10 @@ class CloudFiles:
       return file
 
     def uploadfn(file):
+      if self.max_bps_up >= 0:
+        while tm.current_bps() > self.max_bps_up:
+          time.sleep(0.1)
+
       start_time = time.time()
       file = todict(file)
 

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -669,7 +669,13 @@ class CloudFiles:
       each object (i.e. before decompression) stored in an interval 
       tree. This enables post-hoc analysis of performance.
 
-    Returns: number of files uploaded
+    Returns: 
+      N = number of files uploaded
+      tm = TransmissionMonitor
+      if return_recording:
+        return (N, tm)
+      else:
+        return N
     """
     files = toiter(files)
     progress = nvl(progress, self.progress)

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -671,7 +671,7 @@ class CloudFiles:
       return file
 
     def uploadfn(file):
-      start_time = time.time()
+      start_time = time.monotonic()
       file = todict(file)
 
       file_compress = file.get('compress', compress)
@@ -1376,7 +1376,7 @@ class CloudFiles:
     srcdir = cf_src.cloudpath.replace("file://", "")
     destdir = mkdir(cf_dest.cloudpath.replace("file://", ""))
     for path in paths:
-      start_time = time.time()
+      start_time = time.monotonic()
       if isinstance(path, dict):
         src = os.path.join(srcdir, path["path"])
         dest = os.path.join(destdir, path["dest_path"])
@@ -1438,7 +1438,7 @@ class CloudFiles:
         (found, num_bytes_rx) = conn.save_file(src_key, dest_key, resumable=resumable)
 
       tm.end_io(flight_id, num_bytes_rx)
-      
+
       if found == False and not allow_missing:
         tm.end_error(flight_id)
         raise FileNotFoundError(src_key)

--- a/cloudfiles/cloudfiles.py
+++ b/cloudfiles/cloudfiles.py
@@ -1684,6 +1684,16 @@ class CloudFiles:
       return os.path.join(*paths)
     return posixpath.join(*paths)
 
+  def dirname(self, path:str) -> str:
+    if self._path.protocol == "file":
+      return os.path.dirname(path)
+    return posixpath.dirname(path)
+
+  def basename(self, path:str) -> str:
+    if self._path.protocol == "file":
+      return os.path.basename(path)
+    return posixpath.basename(path)  
+
   def __getitem__(self, key) -> Union[dict,bytes,List[dict]]:
     if isinstance(key, tuple) and len(key) == 2 and isinstance(key[1], slice) and isinstance(key[0], str):
       return self.get({ 'path': key[0], 'start': key[1].start, 'end': key[1].stop })
@@ -1849,6 +1859,12 @@ class CloudFile:
 
   def join(self, *args):
     return self.cf.join(*args)
+
+  def dirname(self, *args):
+    return self.cf.dirname(*args)
+
+  def basename(self, *args):
+    return self.cf.basename(*args)
 
   def touch(self):
     return self.cf.touch(self.filename)

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -1166,10 +1166,7 @@ class S3Interface(StorageInterface):
     is_file_handle = hasattr(content, "read") and hasattr(content, "seek")
 
     if is_file_handle:
-      file_bytes_offset = content.tell()
-      content.seek(0, os.SEEK_END)
-      content_length = content.tell() - file_bytes_offset
-      content.seek(file_bytes_offset)
+      content_length = os.fstat(content.fileno()).st_size
     else:
       content_length = len(content)
 

--- a/cloudfiles/interfaces.py
+++ b/cloudfiles/interfaces.py
@@ -467,7 +467,7 @@ class MemoryInterface(StorageInterface):
       result = result[slice(start, end)]
     return (result, encoding, None, None)
 
-  def save_file(self, src, dest, resumable):
+  def save_file(self, src, dest, resumable) -> tuple[bool,int]:
     key = self.get_path_to_file(src)
     with EXT_TEST_SEQUENCE_LOCK:
       exts = list(EXT_TEST_SEQUENCE)
@@ -489,9 +489,9 @@ class MemoryInterface(StorageInterface):
       with open(dest + true_ext, "wb") as f:
         f.write(self._data[path])
     except KeyError:
-      return False
+      return (False, 0)
 
-    return True
+    return (True, len(self._data[path]))
 
   def head(self, file_path):
     path = self.get_path_to_file(file_path)
@@ -541,13 +541,13 @@ class MemoryInterface(StorageInterface):
 
     return None
 
-  def copy_file(self, src_path, dest_bucket, dest_key):
+  def copy_file(self, src_path, dest_bucket, dest_key) -> tuple[bool,int]:
     key = self.get_path_to_file(src_path)
     with MEM_BUCKET_POOL_LOCK:
      pool = MEM_POOL[MemoryPoolParams(dest_bucket)]
     dest_bucket = pool.get_connection(None, None)
     dest_bucket[dest_key] = self._data[key]
-    return True
+    return (True, len(self._data[key]))
 
   def exists(self, file_path):
     path = self.get_path_to_file(file_path)
@@ -662,7 +662,7 @@ class GoogleCloudStorageInterface(StorageInterface):
     blob.upload_from_string(content, content_type)
 
   @retry
-  def copy_file(self, src_path, dest_bucket, dest_key):
+  def copy_file(self, src_path, dest_bucket, dest_key) -> tuple[bool,int]:
     key = self.get_path_to_file(src_path)
     source_blob = self._bucket.blob( key )
     with GCS_BUCKET_POOL_LOCK:
@@ -670,13 +670,13 @@ class GoogleCloudStorageInterface(StorageInterface):
     dest_bucket = pool.get_connection(self._secrets, None)
 
     try:
-      self._bucket.copy_blob(
+      blob = self._bucket.copy_blob(
         source_blob, dest_bucket, dest_key
       )
     except google.api_core.exceptions.NotFound:
-      return False
+      return (False, 0)
 
-    return True
+    return (True, blob.size)
 
   @retry_if_not(google.cloud.exceptions.NotFound)
   def get_file(self, file_path, start=None, end=None, part_size=None):
@@ -703,7 +703,7 @@ class GoogleCloudStorageInterface(StorageInterface):
     return (content, blob.content_encoding, hash_value, hash_type)
 
   @retry
-  def save_file(self, src, dest, resumable):
+  def save_file(self, src, dest, resumable) -> tuple[bool, int]:
     key = self.get_path_to_file(src)
     blob = self._bucket.blob(key)
     try:
@@ -714,13 +714,15 @@ class GoogleCloudStorageInterface(StorageInterface):
         checksum=None
       )
     except google.cloud.exceptions.NotFound:
-      return False
+      return (False, 0)
+
+    num_bytes = os.path.getsize(dest)
 
     ext = FileInterface.get_extension(blob.content_encoding)
     if not dest.endswith(ext):
       os.rename(dest, dest + ext)
 
-    return True
+    return (True, num_bytes)
 
   @retry_if_not(google.cloud.exceptions.NotFound)
   def head(self, file_path):
@@ -927,7 +929,7 @@ class HttpInterface(StorageInterface):
     return (resp.content, content_encoding, None, None)
 
   @retry
-  def save_file(self, src, dest, resumable):
+  def save_file(self, src, dest, resumable) -> tuple[bool, int]:
     key = self.get_path_to_file(src)
 
     headers = self.head(src)
@@ -948,20 +950,23 @@ class HttpInterface(StorageInterface):
     if resumable and os.path.exists(partname):
       downloaded_size = os.path.getsize(partname)        
 
+    streamed_bytes = 0
+
     range_headers = { "Range": f"bytes={downloaded_size}-" }
     with self.session.get(key, headers=range_headers, stream=True) as resp:
       if resp.status_code not in [200, 206]:
         resp.raise_for_status()
-        return False
+        return (False, 0)
 
       with open(partname, 'ab') as f:
         for chunk in resp.iter_content(chunk_size=int(10e6)):
           f.write(chunk)
+          streamed_bytes += len(chunk)
 
     if resumable:
       os.rename(partname, fulldest)
 
-    return True
+    return (True, streamed_bytes)
 
   @retry
   def exists(self, file_path):
@@ -1205,7 +1210,7 @@ class S3Interface(StorageInterface):
       self._conn.put_object(**attrs)
 
   @retry
-  def copy_file(self, src_path, dest_bucket_name, dest_key):
+  def copy_file(self, src_path, dest_bucket_name, dest_key) -> tuple[bool,int]:
     key = self.get_path_to_file(src_path)
     s3client = self._get_bucket(dest_bucket_name)
     copy_source = {
@@ -1213,7 +1218,7 @@ class S3Interface(StorageInterface):
       'Key': key,
     }
     try:
-      s3client.copy_object(
+      response = s3client.copy_object(
           CopySource=copy_source,
           Bucket=dest_bucket_name,
           Key=dest_key,
@@ -1221,11 +1226,16 @@ class S3Interface(StorageInterface):
       )
     except botocore.exceptions.ClientError as err: 
       if err.response['Error']['Code'] in ('NoSuchKey', '404'):
-        return False
+        return (False, 0)
       else:
         raise
 
-    return True
+    try:
+      num_bytes = int(response["ResponseMetadata"]["HTTPHeaders"]["content-length"])
+    except KeyError:
+      num_bytes = 0
+
+    return (True, num_bytes)
 
   @retry
   def get_file(self, file_path, start=None, end=None, part_size=None):
@@ -1286,14 +1296,14 @@ class S3Interface(StorageInterface):
         raise
 
   @retry
-  def save_file(self, src, dest, resumable):
+  def save_file(self, src, dest, resumable) -> tuple[bool,int]:
     key = self.get_path_to_file(src)
     kwargs = self._additional_attrs.copy()
 
     resp = self.head(src)
 
     if resp is None:
-      return False
+      return (False, 0)
 
     mkdir(os.path.dirname(dest))
 
@@ -1316,11 +1326,12 @@ class S3Interface(StorageInterface):
       )
     except botocore.exceptions.ClientError as err: 
       if err.response['Error']['Code'] in ('NoSuchKey', '404'):
-        return False
+        return (False, 0)
       else:
         raise
 
-    return True
+    num_bytes = os.path.getsize(dest)
+    return (True, num_bytes)
 
   @retry
   def head(self, file_path):

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -149,7 +149,7 @@ class TransmissionMonitor:
       tick_step = len(bins) // 20
 
     timestamps = [ 
-      f"{i*resolution_sec:.2f}" for i in range(0, len(bins), tick_step)
+      f"{i*resolution:.2f}" for i in range(0, len(bins), tick_step)
     ]
     plt.xticks(
       range(0, len(bins), tick_step), 
@@ -158,7 +158,12 @@ class TransmissionMonitor:
       ha='right'
     )
 
-    plt.title('Bytes Transmitted per Second')
+    if resolution == 1.0:
+      text = "Second"
+    else:
+      text = f"{resolution:.2f} Seconds"
+
+    plt.title(f'Bytes Transmitted per {text}')
     plt.xlabel('Time (seconds)')
     plt.ylabel('Bytes Transmitted')
     plt.grid(axis='y', linestyle='--', alpha=0.7)

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -341,7 +341,7 @@ class TransmissionMonitor:
     self.__dict__.update(state)
     self._lock = threading.Lock()
 
-class NetworkSampler:
+class IOSampler:
   def __init__(
     self, 
     buffer_sec:float = 600.0, 

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -269,7 +269,10 @@ class TransmissionMonitor:
 
     fig, ax = plt.subplots(figsize=(10, 5))
 
-    norm = colors.Normalize(vmin=min_file_size, vmax=max_file_size)
+    if max_file_size == min_file_size:
+      norm = colors.Normalize(vmin=0, vmax=max_file_size*1.1)
+    else:
+      norm = colors.Normalize(vmin=min_file_size, vmax=max_file_size)
     cmap = plt.cm.viridis
 
     def human_readable_bytes(x:int) -> str:

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -59,7 +59,6 @@ class TransmissionMonitor:
       lookback_intervals = self._intervaltree[query_us:]
       begin_us = self._intervaltree.begin()
 
-    import pdb; pdb.set_trace()
     num_bytes = 0
     for interval in lookback_intervals:
       if interval.begin > query_us:

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -378,6 +378,11 @@ class IOSampler:
     buffer_sec:float = 600.0, 
     interval:float = 0.25
   ):
+    if buffer_sec <= 0 or interval <= 0:
+      raise ValueError(
+        f"Buffer and interval must be positive. buffer sec: {buffer_sec}, interval: {interval}"
+      )
+
     self._terminate = threading.Event()
     self._thread = None
     self._interval = interval

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -201,8 +201,13 @@ class TransmissionMonitor:
     if show_size_labels is None:
       show_size_labels = len(file_sizes) < 40
 
-    min_file_size = min(file_sizes)
-    max_file_size = max(file_sizes)
+    if len(file_sizes):
+      min_file_size = min(file_sizes)
+      max_file_size = max(file_sizes)
+    else:
+      min_file_size = 0
+      max_file_size = 0
+
     del file_sizes
 
     fig, ax = plt.subplots(figsize=(10, 5))

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -80,7 +80,7 @@ class TransmissionMonitor:
     Compute the current bits per a second with a lookback
     value given in microseconds.
     """
-    look_back_us = look_back_sec * 1e6
+    look_back_us = int(look_back_sec * 1e6)
 
     with self._lock:
       now_us = int(time.time() * 1e6)

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -181,7 +181,6 @@ class TransmissionMonitor:
     per a unit time. Resolution is specified in seconds.
     """
     import matplotlib.pyplot as plt
-    bins = self.histogram(resolution)
 
     xfer = self.histogram(resolution) * 8
     xfer = xfer.astype(np.float32)

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -185,7 +185,7 @@ class TransmissionMonitor:
     self, 
     filename:Optional[str] = None,
     title:Optional[str] = None,
-    show_size_labels:bool = True,
+    show_size_labels:Optional[bool] = None,
   ):
     import matplotlib.pyplot as plt
     import matplotlib.colors as colors
@@ -197,6 +197,9 @@ class TransmissionMonitor:
     with self._lock:
       for interval in self._intervaltree:
         file_sizes.append(interval.data)
+
+    if show_size_labels is None:
+      show_size_labels = len(file_sizes) < 40
 
     min_file_size = min(file_sizes)
     max_file_size = max(file_sizes)

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -325,7 +325,7 @@ class NetworkSampler:
     i = ts.size - 2
     elapsed = 0
     t = ts[-1]
-    while (i >= 0) or (elapsed >= look_back_sec):
+    while (i >= 0) and not (elapsed >= look_back_sec):
       elapsed = t - ts[i]
       i -= 1
     

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -151,6 +151,13 @@ class TransmissionMonitor:
     return np.max(self.histogram(resolution=1.0)) * 8
 
   def histogram(self, resolution:float = 1.0) -> npt.NDArray[np.uint32]:
+
+    if resolution <= 0:
+      raise ValueError(f"Resolution must be positive. Got: {resolution}")
+
+    if not self._intervaltree:
+      return np.array([], dtype=np.uint32)
+
     with self._lock:
       all_begin = int(np.floor(self._intervaltree.begin() / 1e6))
       all_end = int(np.ceil(self._intervaltree.end() / 1e6))

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -386,7 +386,10 @@ class NetworkSampler:
     self._cursor = 0
     self._num_samples = 0
 
-  def start_sampling(self):
+  def start_sampling(self, force=False):
+    if force == False and self.is_sampling():
+      return
+
     self._terminate.set()
     self._terminate = threading.Event()
 
@@ -471,10 +474,14 @@ class NetworkSampler:
       if wait > 0:
         time.sleep(wait)
 
+  def is_sampling(self):
+    return self._thread is not None
+
   def stop_sampling(self):
     self._terminate.set()
     if self._thread is not None:
       self._thread.join()
+    self._thread = None
 
   def __del__(self):
     self.stop_sampling()

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -225,8 +225,10 @@ class TransmissionMonitor:
         factor = (1e6, 'MB')
       elif int(1e9) <= x < int(1e12):
         factor = (1e9, 'GB')
-      else:
+      elif int(1e12) <= x < int(1e15):
         factor = (1e12, 'TB')
+      else:
+        factor = (1e15, 'EB')
 
       return f"{x/factor[0]:.2f} {factor[1]}"
 

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -12,7 +12,6 @@ class TransmissionMonitor:
     self._in_flight_ct = 0
     self._in_flight_bytes = 0
 
-
   @classmethod
   def merge(klass, tms:list["TransmissionMonitor"]) -> "TransmissionMonitor":
     tm = TransmissionMonitor()

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -12,6 +12,18 @@ class TransmissionMonitor:
     self._in_flight_ct = 0
     self._in_flight_bytes = 0
 
+
+  @classmethod
+  def merge(klass, tms:list["TransmissionMonitor"]) -> "TransmissionMonitor":
+    tm = TransmissionMonitor()
+
+    with tm._lock:
+      for other in tms:
+        with other._lock:
+          tm._intervaltree.union(other._intervaltree)
+
+    return tm
+
   def start_io(self, num_bytes:int) -> None:
     with self._lock:
       self._in_flight_ct += 1

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -235,6 +235,9 @@ class TransmissionMonitor:
     else:
       plt.show()
 
+    plt.gca().clear()
+    plt.close('all')
+
   def plot_gantt(
     self, 
     filename:Optional[str] = None,
@@ -337,6 +340,9 @@ class TransmissionMonitor:
       plt.savefig(filename)
     else:
       plt.show()
+
+    plt.gca().clear()
+    plt.close('all')
 
   def __getstate__(self):
     # Copy the object's state from self.__dict__ which contains
@@ -533,6 +539,9 @@ class IOSampler:
       plt.savefig(filename)
     else:
       plt.show()
+
+    plt.gca().clear()
+    plt.close('all')
 
   def _init_sample_buffers(self):
     buffer_size = int(max(np.ceil(self._buffer_sec / self._interval) + 1, 1))

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -226,7 +226,7 @@ class TransmissionMonitor:
             str(i), 
             width=duration,
             left=left,
-            height=3,
+            height=1,
             color=cmap(cval)
           )
           if show_size_labels:

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -299,14 +299,14 @@ class NetworkSampler:
 
     bs, ts = self.samples()
 
-    i = ts.size - 1
+    i = ts.size - 2
     elapsed = 0
     t = ts[-1]
-    while i >= 0:
-      elapsed = ts[i] - t
-      if elapsed >= look_back_sec:
-        break
+    while (i >= 0) or (elapsed >= look_back_sec):
+      elapsed = t - ts[i]
       i -= 1
+    
+    i += 1
 
     if elapsed < 1e-4:
       return 0
@@ -330,11 +330,19 @@ class NetworkSampler:
 
     return bins
 
-  def plot_histogram(self, resolution:float = 0.1, filename:Optional[str] = None) -> None:
+  def plot_histogram(self, resolution:float = None, filename:Optional[str] = None) -> None:
     """
     Plot a bar chart showing the number of bytes transmitted
     per a unit time. Resolution is specified in seconds.
     """
+    if resolution is None:
+      resolution = self._interval
+    elif resolution < self._interval:
+      raise ValueError(
+        f"Can't create histogram bins at a higher resolution "
+        f"than the sample rate. Got: {resolution} Sample Rate: {self._interval}"
+      )
+
     bins = self.histogram(resolution)
     plot_histogram(
       bins, 

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -1,0 +1,161 @@
+import intervaltree
+import threading
+import time
+import numpy as np
+
+class TransmissionMonitor:
+  """Monitors the current transmissing rate of a file set."""
+  def __init__(self):
+    self._intervaltree = intervaltree.IntervalTree()
+    self._lock = threading.Lock()
+    self._total_bytes_landed = 0
+    self._in_flight_ct = 0
+    self._in_flight_bytes = 0
+
+  def start_io(self, num_bytes:int) -> None:
+    with self._lock:
+      self._in_flight_ct += 1
+      self._in_flight_bytes += num_bytes
+
+  def end_io(self, start_sec:float, end_sec:float, num_bytes:int) -> None:
+    """Add a new value to the interval set."""
+    start_us = int(start_sec * 1e6)
+    end_us = int(end_sec * 1e6)
+
+    with self._lock:
+      self._in_flight_ct -= 1
+      self._in_flight_bytes -= num_bytes      
+      self._intervaltree.addi(start_us, end_us, num_bytes)
+      self._total_bytes_landed += num_bytes
+
+  def total_bps(self) -> float:
+    with self._lock:
+      begin = self._intervaltree.begin()
+      end = self._intervaltree.end()
+    return self._total_bytes_landed / ((end - begin) / 1e6) * 8
+
+  def current_bps(self, look_back_sec:float = 2.0) -> float:
+    """
+    Compute the current bits per a second with a lookback
+    value given in microseconds.
+    """
+    look_back_us = look_back_sec * 1e6
+
+    with self._lock:
+      now_us = int(time.time() * 1e6)
+      query_us = now_us - look_back_us
+      lookback_intervals = self._intervaltree[query_us:]
+      begin_us = self._intervaltree.begin()
+
+    import pdb; pdb.set_trace()
+    num_bytes = 0
+    for interval in lookback_intervals:
+      if interval.begin > query_us:
+        num_bytes += interval.data
+      else:
+        adjustment_factor = (interval.end - query_us) / (interval.end - interval.begin)
+        num_bytes += int(round(interval.data * adjustment_factor))
+
+    window_us = min(look_back_us, now_us - begin_us)
+
+    return float(num_bytes) / (window_us / 1e6) * 8
+
+  def total_Mbps(self, *args, **kwargs) -> float:
+    """The total rate in megabits per a second over all files this run."""
+    return self.total_bps(*args, **kwargs) / 1e6
+
+  def total_Gbps(self, *args, **kwargs) -> float:
+    """The total rate in gigabits per a second over all files this run."""
+    return self.total_bps(*args, **kwargs) / 1e9
+
+  def total_MBps(self, *args, **kwargs) -> float:
+    """The total rate in megabytes per a second over all files this run."""
+    return self.total_Mbps(*args, **kwargs) / 8.0
+
+  def total_GBps(self, *args, **kwargs) -> float:
+    """The total rate in gigabytes per a second over all files this run."""
+    return self.total_Gbps(*args, **kwargs) / 8.0
+
+  def current_Mbps(self, *args, **kwargs) -> float:
+    """The current rate in megabits per a second."""
+    return self.current_bps(*args, **kwargs) / 1e6
+
+  def current_Gbps(self, *args, **kwargs) -> float:
+    """The current rate in gigabits per a second."""
+    return self.current_bps(*args, **kwargs) / 1e9
+
+  def current_MBps(self, *args, **kwargs) -> float:
+    """The current rate in megabytes per a second."""
+    return self.current_Mbps(*args, **kwargs) / 8.0
+
+  def current_GBps(self, *args, **kwargs) -> float:
+    """The current rate in gigabytes per a second."""
+    return self.current_Gbps(*args, **kwargs) / 8.0
+
+  def begin(self):
+    with self._lock:
+      return self._intervaltree.begin()
+
+  def end(self):
+    with self._lock:
+      return self._intervaltree.end()
+
+  def histogram(self, bin_resolution_seconds:float = 1.0) -> None:
+    import matplotlib.pyplot as plt
+    
+    with self._lock:
+      all_begin = int(np.floor(self._intervaltree.begin() / 1e6))
+      all_end = int(np.ceil(self._intervaltree.end() / 1e6))
+
+      num_bins = int(np.ceil((all_end - all_begin) / bin_resolution_seconds))
+      bins = np.zeros([ num_bins ], dtype=np.uint32)
+
+      for interval in self._intervaltree:
+        begin = interval.begin / 1e6
+        end = interval.end / 1e6
+
+        elapsed = (interval.end - interval.begin) / 1e6
+
+        if elapsed < bin_resolution_seconds:
+          num_bytes_per_bin = interval.data
+        else:
+          num_bytes_per_bin = round(interval.data / np.ceil(elapsed / bin_resolution_seconds))
+
+        bin_start = int((begin - all_begin) / bin_resolution_seconds)
+        bin_end = int((end - all_begin) / bin_resolution_seconds)
+        bins[bin_start:bin_end+1] += num_bytes_per_bin
+
+    plt.figure(figsize=(10, 6))
+    plt.bar(range(len(bins)), bins, color='dodgerblue')
+
+    tick_step = 1
+    if len(bins) > 20:
+      tick_step = len(bins) // 20
+
+    timestamps = [ 
+      f"{i*bin_resolution_seconds:.2f}" for i in range(0, len(bins), tick_step)
+    ]
+    plt.xticks(
+      range(0, len(bins), tick_step), 
+      timestamps, 
+      rotation=45, 
+      ha='right'
+    )
+
+    plt.title('Bytes Transmitted per Second')
+    plt.xlabel('Time (seconds)')
+    plt.ylabel('Bytes Transmitted')
+    plt.grid(axis='y', linestyle='--', alpha=0.7)
+    plt.tight_layout()
+    plt.show()
+
+
+
+
+
+
+
+
+
+
+

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -35,7 +35,7 @@ class TransmissionMonitor:
     with tm._lock:
       for other in tms:
         with other._lock:
-          tm._intervaltree.union(other._intervaltree)
+          tm._intervaltree = tm._intervaltree.union(other._intervaltree)
 
     return tm
 

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -21,11 +21,13 @@ class TransmissionMonitor:
     self._lock = threading.Lock()
     self._total_bytes_landed = 0
     self._in_flight = {}
-    self._in_flight_bytes = 0
+    
+    # NOTE: _in_flight_bytes doesn't work for downloads b/c we are not
+    # requesting the size of the file up front to avoid perf impact.
+    # _in_flight_bytes isn't necessary unless we are modeling the contribution
+    # of CloudFiles to machine network usage to implement throttling.
+    self._in_flight_bytes = 0 
     self._direction = direction
-
-    # self._network_sampler = NetworkSampler(direction)
-    # self._network_sampler.start_sampling()
 
   @classmethod
   def merge(klass, tms:list["TransmissionMonitor"]) -> "TransmissionMonitor":

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -176,7 +176,7 @@ class TransmissionMonitor:
       filename=filename
     )
 
-  def plot_gant(
+  def plot_gantt(
     self, 
     filename:Optional[str] = None,
     title:Optional[str] = None,

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -175,8 +175,8 @@ class TransmissionMonitor:
     Plot a bar chart showing the number of bytes transmitted
     per a unit time. Resolution is specified in seconds.
     """
-    bins = self.histogram(resolution)
     import matplotlib.pyplot as plt
+    bins = self.histogram(resolution)
 
     xfer = self.histogram(resolution) * 8
     xfer = xfer.astype(np.float32)

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -184,7 +184,7 @@ class TransmissionMonitor:
               per_bin_bytes = total_bytes * (resolution / duration)
               bins[first_bin+1:last_bin] += per_bin_bytes
 
-    return bins.astype(np.uint32)
+    return bins.round().astype(np.uint32)
 
   def plot_histogram(self, resolution:float = 1.0, filename:Optional[str] = None) -> None:
     """

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -356,7 +356,7 @@ class IOSampler:
   def __init__(
     self, 
     buffer_sec:float = 600.0, 
-    interval:float = 0.5
+    interval:float = 0.25
   ):
     self._terminate = threading.Event()
     self._thread = None

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -178,6 +178,19 @@ class TransmissionMonitor:
     plt.tight_layout()
     plt.show()
 
+  def __getstate__(self):
+    # Copy the object's state from self.__dict__ which contains
+    # all our instance attributes. Always use the dict.copy()
+    # method to avoid modifying the original state.
+    state = self.__dict__.copy()
+    # Remove the unpicklable entries.
+    del state['_lock']
+    return state
+
+  def __setstate__(self, state):
+    # Restore instance attributes (i.e., filename and lineno).
+    self.__dict__.update(state)
+    self._lock = threading.Lock()
 
 
 

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -420,8 +420,6 @@ class NetworkSampler:
     bar_width = 0.4
     x_indices = range(len(download_bins))
 
-    import pdb; pdb.set_trace()
-
     plt.bar(
         [x - bar_width/2 for x in x_indices],
         download_bins,

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -709,3 +709,9 @@ class IOSampler:
     self._terminate_evt = threading.Event()
     self._thread = None
 
+  def __enter__(self):
+    self.start_sampling()
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    self.stop_sampling()

--- a/cloudfiles/monitoring.py
+++ b/cloudfiles/monitoring.py
@@ -41,10 +41,19 @@ class TransmissionMonitor:
       self._total_bytes_landed += num_bytes
 
   def total_bps(self) -> float:
+    """Average bits per second sent during the entire session."""
     with self._lock:
       begin = self._intervaltree.begin()
       end = self._intervaltree.end()
     return self._total_bytes_landed / ((end - begin) / 1e6) * 8
+
+  def total_bytes(self) -> int:
+    """Sum of all bytes sent."""
+    num_bytes = 0
+    with self._lock:
+      for interval in self._intervaltree:
+        num_bytes += interval.data
+    return num_bytes
 
   def current_bps(self, look_back_sec:float = 2.0) -> float:
     """

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -294,7 +294,7 @@ def _cp_single(
       pass
 
     if use_stdout:
-      fn = partial(_cp_stdout, srcpath, no_sign_request)
+      fn = partial(_cp_stdout, srcpath, no_sign_request, gantt)
     else:
       fn = partial(
         _cp, srcpath, destpath, compression, False, 

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -25,7 +25,7 @@ import pathos.pools
 import cloudfiles
 import cloudfiles.paths
 from cloudfiles import CloudFiles
-from cloudfiles.monitoring import TransmissionMonitor, NetworkSampler, IOEnum
+from cloudfiles.monitoring import TransmissionMonitor, IOSampler, IOEnum
 from cloudfiles.resumable_tools import ResumableTransfer
 from cloudfiles.compression import transcode
 from cloudfiles.paths import extract, get_protocol, find_common_buckets
@@ -206,7 +206,7 @@ def cp(
 
   network_sampler = None
   if machine_io_chart:
-    network_sampler = NetworkSampler(
+    network_sampler = IOSampler(
       buffer_sec=machine_io_chart_buffer_sec,
       interval=0.25,
     )

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -180,7 +180,7 @@ def get_mfp(path, recursive):
 @click.option('--part-bytes', default=int(1e8), help="Composite upload threshold in bytes. Splits a file into pieces for some cloud services like gs and s3.", show_default=True)
 @click.option('--no-sign-request', is_flag=True, default=False, help="Use s3 in anonymous mode (don't sign requests) for the source.", show_default=True)
 @click.option('--resumable', is_flag=True, default=False, help="http->file transfers will dowload to .part files while they are in progress.", show_default=True)
-@click.option('--gantt', is_flag=True, default=False, help="Save a Gantt chart of the file transfer to the local directory.", show_default=True)
+@click.option('--flight-time', is_flag=True, default=False, help="Save a Gantt chart of the file transfer to the local directory.", show_default=True)
 @click.option('--io-chart', is_flag=True, default=False, help="Save a chart of bits per a second based on file sizes and transmission times.", show_default=True)
 @click.option('--machine-io-chart', is_flag=True, default=False, help="Save a chart of bits per a second based on 4 Hz sampling OS network counters for the entire machine.", show_default=True)
 @click.option('--machine-io-chart-buffer-sec', default=600, help="Circular buffer length in seconds. Only allocated if chart enabled. 1 sec = 96 bytes", show_default=True)
@@ -190,7 +190,7 @@ def cp(
   recursive, compression, progress, 
   block_size, part_bytes, no_sign_request,
   resumable, 
-  gantt, io_chart, 
+  flight_time, io_chart, 
   machine_io_chart, machine_io_chart_buffer_sec,
 ):
   """
@@ -217,11 +217,11 @@ def cp(
       ctx, src, destination, recursive, 
       compression, progress, block_size, 
       part_bytes, no_sign_request,
-      resumable, gantt, io_chart,
+      resumable, flight_time, io_chart,
     )
 
   if machine_io_chart:
-    filename = f"./cloudfiles-cp-machine-io-{_timestamp()}.png"
+    filename = f"./cloudfiles-cp-measured-io-{_timestamp()}.png"
     network_sampler.stop_sampling()
     network_sampler.plot_histogram(
       resolution=1.0,
@@ -362,12 +362,12 @@ def _cp_single(
   ts = _timestamp()
 
   if io_chart:
-    filename = f"./cloudfiles-cp-histogram-{ts}.png"
+    filename = f"./cloudfiles-cp-est-io-{ts}.png"
     tm.plot_histogram(filename=filename)
     print(f"Saved chart: {filename}")
 
   if gantt:
-    filename = f"./cloudfiles-cp-gantt-{ts}.png"
+    filename = f"./cloudfiles-cp-flight-time-{ts}.png"
     tm.plot_gantt(filename=filename)
     print(f"Saved chart: {filename}")
 
@@ -388,12 +388,12 @@ def _cp(
   ts = _timestamp()
 
   if io_chart:
-    filename = f"./cloudfiles-cp-histogram-{ts}.png"
+    filename = f"./cloudfiles-cp-est-io-{ts}.png"
     tm.plot_histogram(filename=filename)
     print(f"Saved chart: {filename}")
 
   if gantt:
-    filename = f"./cloudfiles-cp-gantt-{ts}.png"
+    filename = f"./cloudfiles-cp-flight-time-{ts}.png"
     tm.plot_gantt(filename=filename)
     print(f"Saved chart: {filename}")
 
@@ -411,10 +411,10 @@ def _cp_stdout(src, no_sign_request, gantt, io_chart, paths):
   ts = _timestamp()
 
   if io_chart:
-    tm.plot_histogram(filename=f"./cloudfiles-cp-histogram-{ts}.png")
+    tm.plot_histogram(filename=f"./cloudfiles-cp-est-io-{ts}.png")
 
   if gantt:
-    tm.plot_gantt(filename=f"./cloudfiles-cp-gantt-{ts}.png")
+    tm.plot_gantt(filename=f"./cloudfiles-cp-flight-time-{ts}.png")
 
   for res in results:
     content = res["content"].decode("utf8")

--- a/cloudfiles_cli/cloudfiles_cli.py
+++ b/cloudfiles_cli/cloudfiles_cli.py
@@ -317,11 +317,11 @@ def _cp_single(
       pass
 
     if use_stdout:
-      fn = partial(_cp_stdout, srcpath, no_sign_request, False)
+      fn = partial(_cp_stdout, srcpath, no_sign_request, False, False)
     else:
       fn = partial(
         _cp, srcpath, destpath, compression, False, 
-        block_size, part_bytes, no_sign_request, resumable, False
+        block_size, part_bytes, no_sign_request, resumable, False, False,
       )
 
     tms = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ google-auth>=1.10.0
 google-cloud-core>=1.1.0
 google-cloud-storage>=1.31.1
 google-crc32c>=1.0.0
+intervaltree
 orjson
 pathos
 protobuf>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ intervaltree
 orjson
 pathos
 protobuf>=3.3.0
+psutil
 requests>=2.22.0
 six>=1.14.0
 tenacity>=4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,9 @@ google-auth>=1.10.0
 google-cloud-core>=1.1.0
 google-cloud-storage>=1.31.1
 google-crc32c>=1.0.0
-intervaltree
 orjson
 pathos
 protobuf>=3.3.0
-psutil
 requests>=2.22.0
 six>=1.14.0
 tenacity>=4.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,5 @@ monitoring =
     psutil
     intervaltree
     matplotlib
+apache = 
+    lxml

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,7 @@ test =
     moto>=5
 numpy =
     numpy
+monitoring = 
+    psutil
+    intervaltree
+    matplotlib


### PR DESCRIPTION
This PR adds estimated and global measurements for upload and download speed and provides a matplotlib based chart for different capabilities.

In the CLI, this adds:

- `--flight-time` which shows a gantt chart of the flight time of different files colored by file size.
- `--machine-io-rate` samples the OS network counters to measure the total network IO on the machine
- `--machine-io-rate-buffer-sec` sets the size of the circular buffer in seconds, the sampling interval is 0.25 seconds.
- `--io-rate` estimates the IO contribution from file flight times. This is useful when CloudFiles is not the only network traffic on the machine. You can use the two measurements to figure out the relative contribution of different processes.

This PR also introduces two new objects:

- `TransmissionMonitor`: This object records the flight times of files within a CloudFiles instance. It is integrated to all CloudFiles transfers and can be accessed with `return_recording`. It allows you to estimate the current and peak bits per a second as well as identify straggler files. This object can generate time of flight charts and estimated transfer rates.
- `IOSampler`: This object is not enabled by default, but can be switched on ideally as a singleton. `sampler.start_sampling()` will launch a background thread that measures OS IO counters using psutil and records them into a circular buffer of a user specified length in seconds. This object can plot the measured transfer rate.







