### PR TITLE
perf: Prefer GIL-releasing isal over deflate

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 Manuel Castro <macastro@princeton.edu>
-Nico Kemnitz <nkemnitz@princeton.edu>
+Nico Kemnitz <nico@zetta.ai>
 V24 <55334829+umarfarouk98@users.noreply.github.com>
 William Silversmith <william.silversmith@gmail.com>
 madiganz <madiganz@users.noreply.github.com>

--- a/cloudfiles/compression.py
+++ b/cloudfiles/compression.py
@@ -7,6 +7,11 @@ import lzma
 import sys
 
 try:
+  from isal import igzip as isal_igzip
+except ImportError:
+  isal_igzip = None
+
+try:
   import deflate
 except ImportError:
   deflate = None
@@ -166,9 +171,21 @@ def compress(content, method='gzip', compress_level=None):
   
   raise ValueError(str(method) + ' is not currently supported. Supported Options: None, gzip, br')
 
+def _gzip_to_isal_level(compresslevel):
+  if compresslevel <= 0:
+    return 0
+  elif compresslevel <= 3:
+    return 1
+  elif compresslevel <= 6:
+    return 2
+  return 3
+
 def gzip_compress(content, compresslevel=None):
   if compresslevel is None:
     compresslevel = 9
+
+  if isal_igzip is not None:
+    return isal_igzip.compress(content, _gzip_to_isal_level(compresslevel))
 
   if deflate:
     return bytes(deflate.gzip_compress(content, compresslevel))
@@ -200,6 +217,9 @@ def gunzip(content):
     raise DecompressionError('File is not in gzip format. Magic numbers {}, {} did not match {}, {}.'.format(
       hex(first_two_bytes[0]), hex(first_two_bytes[1]), hex(gzip_magic_numbers[0]), hex(gzip_magic_numbers[1])
     ))
+
+  if isal_igzip is not None:
+    return isal_igzip.decompress(content)
 
   if deflate:
     return bytes(deflate.gzip_decompress(content))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ crc32c
 chardet>=3.0.4
 click
 deflate>=0.2.0
+isal>=1.8.0; (platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "aarch64" or platform_machine == "arm64") and implementation_name == "cpython"
 gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0


### PR DESCRIPTION
_Single-threaded_ [isal](https://pypi.org/project/isal/) itself already gives a significant speed-boost for compression (3.3x !?) and decompression (1.2x) on my local i7-12700 over `deflate`, But more importantly, it releases the GIL, no longer blocks the other worker-threads in multi-threaded Python (e.g. CloudVolume).

Wheels are available for all major platforms and CPython versions, but I hid it behind a guard for graceful fallback to `deflate`, just in case.